### PR TITLE
ci: rename backend service to backend-prod in docker-compose-prod.yml

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  backend:
+  backend-prod:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
The change aligns the service name with the production environment convention, improving clarity and consistency in the deployment configuration.