### PR TITLE
Add convert-to-member endpoint; default CONFIRMED

### DIFF
--- a/src/modules/visitorManagement/visitorController.ts
+++ b/src/modules/visitorManagement/visitorController.ts
@@ -73,4 +73,28 @@ export class VisitorController {
         .json({ message: "Error deleting visitor", error: error.message });
     }
   }
+
+  async convertVisitorToMember(req: Request, res: Response) {
+    try {
+      const { id } = req.query;
+
+      if (!id || Number.isNaN(Number(id))) {
+        return res
+          .status(400)
+          .json({ message: "Invalid or missing visitor id" });
+      }
+
+      const user = await visitorService.changeVisitorStatusToMember(Number(id));
+
+      return res.status(200).json({
+        message: "Visitor converted to member successfully",
+        data: user,
+      });
+    } catch (error: any) {
+      return res.status(500).json({
+        message: "Error converting visitor to member",
+        error: error.message,
+      });
+    }
+  }
 }

--- a/src/modules/visitorManagement/visitorRoute.ts
+++ b/src/modules/visitorManagement/visitorRoute.ts
@@ -20,6 +20,11 @@ visitorRouter.get("/visitors", visitorController.getAllVisitors);
 visitorRouter.get("/visitor", visitorController.getVisitorsById);
 visitorRouter.put("/visitor", visitorController.updateVisitor);
 visitorRouter.delete("/visitor", visitorController.deleteVisitor);
+visitorRouter.post(
+  "/convert-to-member",
+  [protect, permissions.can_Manage_Members],
+  visitorController.convertVisitorToMember,
+);
 
 //visitor routes
 visitorRouter.post("/visit", visitController.createVisit);

--- a/src/modules/visitorManagement/visitorService.ts
+++ b/src/modules/visitorManagement/visitorService.ts
@@ -346,7 +346,7 @@ export class VisitorService {
       },
       picture: {},
       children: [],
-      status: "active",
+      status: "CONFIRMED",
       password: "123456", // default or auto-generated
       is_user: true,
     };


### PR DESCRIPTION
Add VisitorController.convertVisitorToMember and a protected POST /convert-to-member route (requires protect and permissions.can_Manage_Members). The controller validates the id query param, calls visitorService.changeVisitorStatusToMember, and returns appropriate success/error responses. Also update the default user status value from "active" to "CONFIRMED" when creating the member object.