### PR TITLE
Support attendee fields and flexible session input

### DIFF
--- a/src/modules/appointment/appointment-controller.ts
+++ b/src/modules/appointment/appointment-controller.ts
@@ -162,7 +162,10 @@ export class AppointmentController {
   async getBookings(req: Request, res: Response) {
     try {
       const staffIdRaw =
-        req.query.staffId ?? req.query.staffId ?? req.query.userId;
+        req.query.staffId ??
+        req.query.userId ??
+        req.query.attendeeId ??
+        req.query.attendee_id;
       const requesterIdRaw = req.query.requesterId ?? req.query.requestedBy;
       const email =
         typeof req.query.email === "string" ? req.query.email : undefined;


### PR DESCRIPTION
Accept attendeeId/attendee_id as alternative user/staff identifiers and include them when resolving staff/requester IDs. Add utilities (firstValidString, hasSessionInput) and make resolveSession accept multiple field variants (camelCase/snake_case and alternate names) for start/end; validate and trim values. Update presence check for session input and improve error messaging to reflect attendee field names.