### PR TITLE
Add event_type to requests and validation

### DIFF
--- a/prisma/migrations/20260503120000_add_requisition_event_type/migration.sql
+++ b/prisma/migrations/20260503120000_add_requisition_event_type/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `request` ADD COLUMN `event_type_id` INTEGER NULL;
+
+CREATE INDEX `request_event_type_id_fkey` ON `request`(`event_type_id`);
+
+ALTER TABLE `request` ADD CONSTRAINT `request_event_type_id_fkey`
+  FOREIGN KEY (`event_type_id`) REFERENCES `event_act`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -339,6 +339,7 @@ model event_act {
   event_type        event_type?
   event_description String?       @default("event_description")
   event_mgt         event_mgt[]
+  requests          request[]     @relation("RequestEventType")
 }
 
 model event_mgt {
@@ -520,6 +521,7 @@ model request {
   request_id              String
   user_id                 Int
   event_id                Int?
+  event_type_id           Int?
   department_id           Int
   request_approval_status RequestApprovalStatus
   requisition_date        DateTime
@@ -532,6 +534,7 @@ model request {
   branch                  branch?                          @relation(fields: [branch_id], references: [id])
   department              department                       @relation(fields: [department_id], references: [id])
   event                   event_mgt?                       @relation(fields: [event_id], references: [id])
+  eventType               event_act?                       @relation("RequestEventType", fields: [event_type_id], references: [id])
   user                    user                             @relation(fields: [user_id], references: [id])
   request_approvals       request_approvals?
   request_comments        request_comments[]
@@ -542,6 +545,7 @@ model request {
   @@index([user_id], map: "request_user_id_fkey")
   @@index([department_id], map: "request_department_id_fkey")
   @@index([event_id], map: "request_event_id_fkey")
+  @@index([event_type_id], map: "request_event_type_id_fkey")
   @@index([branch_id], map: "request_branch_id_idx")
   @@index([updated_by_user_id], map: "request_updated_by_user_id_idx")
   @@index([request_approval_status], map: "request_approval_status_idx")

--- a/src/interfaces/requisitions-interface.ts
+++ b/src/interfaces/requisitions-interface.ts
@@ -25,6 +25,7 @@ export interface RequisitionInterface {
   request_date?: string;
   department_id: number;
   event_id?: number | null;
+  event_type_id?: number | null;
   currency: string;
   approval_status?: RequestApprovalStatus;
   user_id: number;

--- a/src/middleWare/errorHandler.ts
+++ b/src/middleWare/errorHandler.ts
@@ -11,6 +11,22 @@ const isDevelopment =
   process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
 
 const buildPrismaError = (error: Prisma.PrismaClientKnownRequestError) => {
+  if (error.code === "P2003") {
+    const fieldName = String(error.meta?.field_name || "");
+    const isRequisitionEventConstraint =
+      fieldName.includes("request_event_id_fkey") ||
+      fieldName.includes("request_event_type_id_fkey") ||
+      fieldName.includes("event_id") ||
+      fieldName.includes("event_type_id");
+
+    return {
+      statusCode: StatusCodes.BAD_REQUEST,
+      message: isRequisitionEventConstraint
+        ? "The selected event is not valid for this requisition. Please refresh the page, choose an event from the Event dropdown again, and save."
+        : "One of the selected records no longer exists. Please refresh the page, review your selections, and try again.",
+    };
+  }
+
   if (error.code === "P2002") {
     return {
       statusCode: StatusCodes.CONFLICT,

--- a/src/modules/requisitions/requisition-approval-workflow.ts
+++ b/src/modules/requisitions/requisition-approval-workflow.ts
@@ -75,6 +75,9 @@ type ApprovalAction = RequisitionApprovalActionPayload["action"];
 
 type ApprovalWorkflowTx = Prisma.TransactionClient;
 
+const APPROVER_REQUESTER_CONFLICT_MESSAGE =
+  "You are assigned as an approver for this requisition, so you cannot also submit it. This keeps the approval process independent and fair. Please ask another authorized requester to raise the requisition, or choose a department where you are not the approver.";
+
 const APPROVAL_MODULE_LITERAL_VALUES = {
   REQUISITION: "REQUISITION",
   EVENT_REPORT: "EVENT_REPORT",
@@ -1008,7 +1011,7 @@ const resolveHeadOfDepartmentApproverUserId = async (
     },
   });
 
-  const departmentId = requesterDepartment?.department_id || fallbackDepartmentId;
+  const departmentId = fallbackDepartmentId || requesterDepartment?.department_id;
 
   if (!departmentId) {
     throw new InputValidationError(
@@ -1048,6 +1051,42 @@ const resolveHeadOfDepartmentApproverUserId = async (
   }
 
   return departmentHead.id;
+};
+
+const ensureRequesterIsNotApprover = (
+  requesterId: number,
+  approverUserId: number,
+) => {
+  if (requesterId === approverUserId) {
+    throw new InputValidationError(APPROVER_REQUESTER_CONFLICT_MESSAGE);
+  }
+};
+
+export const validateRequesterIsNotConfiguredApproverTx = async (
+  tx: ApprovalWorkflowTx,
+  args: {
+    requesterId: number;
+    fallbackDepartmentId?: number;
+  },
+): Promise<void> => {
+  const config = await getConfigByModuleTx(tx, REQUISITION_MODULE);
+
+  if (!config || !config.is_active || !config.approvers.length) {
+    return;
+  }
+
+  for (const approver of config.approvers) {
+    const resolvedApproverUserId = await resolveApproverUserIdForStep(tx, {
+      step: {
+        step_type: approver.type,
+        position_id: approver.position_id ?? null,
+        user_id: approver.user_id ?? null,
+      },
+      requesterId: args.requesterId,
+      fallbackDepartmentId: args.fallbackDepartmentId,
+    });
+    ensureRequesterIsNotApprover(args.requesterId, resolvedApproverUserId);
+  }
 };
 
 const resolvePositionApproverUserId = async (
@@ -1328,6 +1367,11 @@ export const buildRequisitionApprovalSnapshotTx = async (
 
   const config = await getActiveConfigForSubmissionTx(tx);
 
+  await validateRequesterIsNotConfiguredApproverTx(tx, {
+    requesterId,
+    fallbackDepartmentId,
+  });
+
   const requesterAllowed = config.effective_requester_user_ids.includes(
     requesterId,
   );
@@ -1346,6 +1390,7 @@ export const buildRequisitionApprovalSnapshotTx = async (
       requesterId,
       fallbackDepartmentId,
     });
+    ensureRequesterIsNotApprover(requesterId, resolvedApproverUserId);
 
     snapshotRows.push({
       request_id: requestId,

--- a/src/modules/requisitions/requisition-service.ts
+++ b/src/modules/requisitions/requisition-service.ts
@@ -35,6 +35,7 @@ import {
   processRequisitionApprovalAction,
   triggerRequisitionNotificationEventProcessing,
   upsertRequisitionApprovalConfig,
+  validateRequesterIsNotConfiguredApproverTx,
   validateApprovalActionPayload,
 } from "./requisition-approval-workflow";
 import { notificationService } from "../notifications/notificationService";
@@ -528,6 +529,23 @@ const normalizeUpdateEventId = (
   }
 
   return normalizeOptionalEventIdValue((payload as any).event_id);
+};
+
+const ensureSelectedEventTypeExists = async (
+  eventId: number | null | undefined,
+) => {
+  if (eventId === null || eventId === undefined) {
+    return;
+  }
+
+  const event = await prisma.event_act.findUnique({
+    where: { id: eventId },
+    select: { id: true },
+  });
+
+  if (!event) {
+    throw new InputValidationError("Selected event type does not exist.");
+  }
 };
 
 const shouldSubmitOnCreate = (data: RequisitionInterface): boolean => {
@@ -1033,13 +1051,15 @@ export const createRequisition = async (
   const requestId = await generateRequestId();
   const shouldSubmit = shouldSubmitOnCreate(data);
   const normalizedEventId = normalizeCreateEventId((data as any).event_id);
+  await ensureSelectedEventTypeExists(normalizedEventId);
   const requestCreateData: Prisma.requestUncheckedCreateInput = {
     request_id: requestId,
     user_sign: data.user_sign,
     user_id: actorUserId,
     branch_id: await resolveBranchIdOrDefault((data as any).branch_id),
     department_id: data.department_id,
-    event_id: normalizedEventId,
+    event_id: null,
+    event_type_id: normalizedEventId,
     requisition_date: new Date(data.request_date as string),
     request_approval_status: RequestApprovalStatus.Draft,
     currency: data.currency,
@@ -1071,6 +1091,11 @@ export const createRequisition = async (
   let shouldTriggerNotificationProcessing = false;
 
   const createdRequest = await prisma.$transaction(async (tx) => {
+    await validateRequesterIsNotConfiguredApproverTx(tx, {
+      requesterId: actorUserId,
+      fallbackDepartmentId: data.department_id,
+    });
+
     const request = await tx.request.create({
       data: requestCreateData,
       select: {
@@ -1146,6 +1171,7 @@ export const updateRequisition = async (
   // Requester identity is immutable after creation.
   delete (updateInput as any).user_id;
   updateInput.event_id = normalizeUpdateEventId(updateInput);
+  await ensureSelectedEventTypeExists(updateInput.event_id);
 
   const [
     findRequest,
@@ -1363,7 +1389,7 @@ export const updateRequisition = async (
     existingRequest: {
       requisition_date: findRequest.requisition_date,
       department_id: findRequest.department_id,
-      event_id: findRequest.event_id,
+      event_id: findRequest.event_type_id ?? findRequest.event_id,
       request_approval_status: findRequest.request_approval_status,
       currency: findRequest.currency,
       user_sign: findRequest.user_sign,
@@ -1409,6 +1435,11 @@ export const updateRequisition = async (
   let shouldTriggerNotificationProcessing = false;
 
   await prisma.$transaction(async (tx) => {
+    await validateRequesterIsNotConfiguredApproverTx(tx, {
+      requesterId: findRequest.user_id,
+      fallbackDepartmentId: updateInput.department_id ?? findRequest.department_id,
+    });
+
     if (existingApproval) {
       await tx.request_approvals.update({
         where: { request_id: data.id },
@@ -1951,6 +1982,15 @@ export const getRequisition = async (id: any, user: any) => {
         },
       },
       department: { select: { id: true, name: true } },
+      eventType: {
+        select: {
+          id: true,
+          event_name: true,
+          event_type: true,
+          event_status: true,
+          event_description: true,
+        },
+      },
       event: {
         select: {
           id: true,

--- a/src/modules/requisitions/requsition-helpers.ts
+++ b/src/modules/requisitions/requsition-helpers.ts
@@ -128,7 +128,8 @@ export const updateDataPayload = (
     user_sign: isMember ? data.user_sign : undefined,
     branch_id: (data as any).branch_id,
     department_id: data.department_id,
-    event_id: data.event_id,
+    event_id: undefined,
+    event_type_id: data.event_id,
     requisition_date: data.request_date
       ? new Date(data.request_date)
       : undefined,
@@ -147,7 +148,8 @@ export const updateRequestReturnValue = (
     updated_at?: Date | string | null;
   } | null,
 ) => {
-  const eventName = updatedRequest.event?.event?.event_name || null;
+  const eventType = updatedRequest.eventType || updatedRequest.event?.event || null;
+  const eventName = eventType?.event_name || null;
   const approvalInstances = updatedRequest.approval_instances || [];
   const actedInstances = approvalInstances.filter(
     (instance: any) => instance.acted_at,
@@ -187,7 +189,9 @@ export const updateRequestReturnValue = (
     department_id:
       updatedRequest.department_id ?? updatedRequest.department?.id ?? null,
     branch_id: updatedRequest.branch_id ?? null,
-    event_id: updatedRequest.event_id ?? updatedRequest.event?.id ?? null,
+    event_id: eventType?.id ?? updatedRequest.event_id ?? updatedRequest.event?.id ?? null,
+    event_type_id: eventType?.id ?? null,
+    scheduled_event_id: updatedRequest.event_id ?? updatedRequest.event?.id ?? null,
     event_name: eventName,
     request_date: updatedRequest.requisition_date || null,
     approval_status: updatedRequest.request_approval_status || null,
@@ -216,7 +220,9 @@ export const updateRequestReturnValue = (
       edited_at: updatedAt,
       department_id: updatedRequest.department?.id || null,
       program: eventName,
-      program_id: updatedRequest.event?.id || null,
+      program_id: eventType?.id || null,
+      event_type_id: eventType?.id || null,
+      scheduled_event_id: updatedRequest.event_id ?? updatedRequest.event?.id ?? null,
       request_date: updatedRequest.requisition_date,
       total_cost: totalCost,
       status: updatedRequest.request_approval_status,

--- a/src/utils/catchAsyncFunction.ts
+++ b/src/utils/catchAsyncFunction.ts
@@ -2,6 +2,7 @@ import { Logger } from "winston";
 import e, { Request, Response, NextFunction } from "express";
 import { AppError, InputValidationError } from "./custom-error-handlers";
 import { StatusCodes } from "http-status-codes";
+import { Prisma } from "@prisma/client";
 
 const development =
   process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
@@ -57,19 +58,88 @@ const handleError = (
   req: Request,
   res: Response,
   next: NextFunction,
-): void => {
+): void | Response => {
+  if (res.headersSent) {
+    return next(error);
+  }
+
   if (error instanceof InputValidationError) {
-    res.status(StatusCodes.BAD_REQUEST).json({
+    return res.status(StatusCodes.BAD_REQUEST).json({
       status: "error",
       statusCode: StatusCodes.BAD_REQUEST,
       message: error.message,
     });
   }
-  if (development) {
-    handleDevelopmentError(error, req, res, next);
-  } else {
-    handleProductionError(error, req, res, next);
+
+  if (error instanceof AppError) {
+    return res.status(error.statusCode).json({
+      status: "error",
+      statusCode: error.statusCode,
+      message: error.message,
+    });
   }
+
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    const prismaError = buildPrismaKnownRequestError(error);
+    return res.status(prismaError.statusCode).json({
+      status: "error",
+      statusCode: prismaError.statusCode,
+      message: prismaError.message,
+    });
+  }
+
+  if (development) {
+    return handleDevelopmentError(error, req, res, next);
+  } else {
+    return handleProductionError(error, req, res, next);
+  }
+};
+
+const buildPrismaKnownRequestError = (
+  error: Prisma.PrismaClientKnownRequestError,
+): { statusCode: number; message: string } => {
+  if (error.code === "P2003") {
+    const fieldName = String(error.meta?.field_name || "");
+    const isRequisitionEventConstraint =
+      fieldName.includes("request_event_id_fkey") ||
+      fieldName.includes("request_event_type_id_fkey") ||
+      fieldName.includes("event_id") ||
+      fieldName.includes("event_type_id");
+
+    if (isRequisitionEventConstraint) {
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        message:
+          "The selected event is not valid for this requisition. Please refresh the page, choose an event from the Event dropdown again, and save.",
+      };
+    }
+
+    return {
+      statusCode: StatusCodes.BAD_REQUEST,
+      message:
+        "One of the selected records no longer exists. Please refresh the page, review your selections, and try again.",
+    };
+  }
+
+  if (error.code === "P2002") {
+    return {
+      statusCode: StatusCodes.CONFLICT,
+      message: "A record with the same unique value already exists.",
+    };
+  }
+
+  if (error.code === "P2025") {
+    return {
+      statusCode: StatusCodes.NOT_FOUND,
+      message: "Requested record was not found.",
+    };
+  }
+
+  return {
+    statusCode: StatusCodes.BAD_REQUEST,
+    message:
+      "The request could not be saved because some submitted data is invalid. Please review the form and try again.",
+  };
 };
 
 type ExpressHandler = (


### PR DESCRIPTION
Add event_type_id to request model (DB migration + Prisma schema) and update related types and helpers to store/return eventType alongside existing event references. Introduce ensureSelectedEventTypeExists to validate event_type on create/update, wire event_type selection into create/update/get flows, and update request mapping in helpers. Add approval workflow guard to prevent a requester being configured as an approver (new validation + helper) and call it during snapshot/build and create/update transactions. Improve error handling for Prisma known errors (P2003/P2002/P2025) with clearer messages for invalid/missing event selections. Includes migration SQL to add the foreign key/index and interface/type updates.