### PR TITLE
Add biometric staging and account deletion APIs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,8 +43,8 @@ const app = express();
 
 app.disable("x-powered-by");
 app.use(cors());
-app.use(express.json({ limit: "1mb" }));
-app.use(express.urlencoded({ extended: true, limit: "1mb" }));
+app.use(express.json({ limit: "25mb" }));
+app.use(express.urlencoded({ extended: true, limit: "25mb" }));
 app.use(logRequests);
 app.use(responseMessageEnhancer);
 app.use(appRouter);

--- a/prisma/migrations/20260513120000_add_biometric_stage_batches/migration.sql
+++ b/prisma/migrations/20260513120000_add_biometric_stage_batches/migration.sql
@@ -1,0 +1,64 @@
+ALTER TABLE `event_biometric_import_job`
+  ADD COLUMN `source_stage_batch_id` INTEGER NULL;
+
+CREATE TABLE `event_biometric_stage_batch` (
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
+  `status` ENUM('QUEUED', 'RUNNING', 'COMPLETED', 'FAILED') NOT NULL DEFAULT 'QUEUED',
+  `source` VARCHAR(191) NOT NULL DEFAULT 'ZTECO_LIBRARY',
+  `total_punches` INTEGER NOT NULL DEFAULT 0,
+  `staged_punches` INTEGER NOT NULL DEFAULT 0,
+  `duplicate_punches` INTEGER NOT NULL DEFAULT 0,
+  `event_count` INTEGER NOT NULL DEFAULT 0,
+  `request_payload` JSON NOT NULL,
+  `result_payload` JSON NULL,
+  `error_message` TEXT NULL,
+  `created_by` INTEGER NOT NULL,
+  `created_by_name` VARCHAR(191) NOT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `started_at` DATETIME(3) NULL,
+  `completed_at` DATETIME(3) NULL,
+  `failed_at` DATETIME(3) NULL,
+  `updated_at` DATETIME(3) NOT NULL,
+
+  INDEX `event_biometric_stage_batch_status_created_idx`(`status`, `created_at`),
+  INDEX `event_biometric_stage_batch_created_by_time_idx`(`created_by`, `created_at`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `event_biometric_stage_punch` (
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
+  `batch_id` INTEGER NOT NULL,
+  `device_id` INTEGER NULL,
+  `device_ip` VARCHAR(191) NOT NULL,
+  `device_port` VARCHAR(191) NULL,
+  `device_user_id` VARCHAR(191) NOT NULL,
+  `device_user_name` VARCHAR(191) NULL,
+  `record_time` DATETIME(3) NOT NULL,
+  `state` INTEGER NOT NULL DEFAULT -1,
+  `source_fingerprint` VARCHAR(191) NOT NULL,
+  `raw_payload` JSON NOT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+  UNIQUE INDEX `event_biometric_stage_punch_batch_fingerprint_key`(`batch_id`, `source_fingerprint`),
+  INDEX `event_biometric_stage_punch_batch_time_idx`(`batch_id`, `record_time`),
+  INDEX `event_biometric_stage_punch_device_time_idx`(`device_ip`, `record_time`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `event_biometric_import_job`
+  ADD INDEX `event_biometric_import_job_stage_batch_idx`(`source_stage_batch_id`);
+
+ALTER TABLE `event_biometric_import_job`
+  ADD CONSTRAINT `event_biometric_import_job_source_stage_batch_id_fkey`
+    FOREIGN KEY (`source_stage_batch_id`) REFERENCES `event_biometric_stage_batch`(`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE `event_biometric_stage_batch`
+  ADD CONSTRAINT `event_biometric_stage_batch_created_by_fkey`
+    FOREIGN KEY (`created_by`) REFERENCES `user`(`id`)
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE `event_biometric_stage_punch`
+  ADD CONSTRAINT `event_biometric_stage_punch_batch_id_fkey`
+    FOREIGN KEY (`batch_id`) REFERENCES `event_biometric_stage_batch`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model user {
   matched_biometric_punches event_biometric_punch[] @relation("event_biometric_punch_matched_user")
   imported_biometric_punches event_biometric_punch[] @relation("event_biometric_punch_imported_by_user")
   created_biometric_import_jobs event_biometric_import_job[] @relation("event_biometric_import_job_created_by_user")
+  created_biometric_stage_batches event_biometric_stage_batch[] @relation("event_biometric_stage_batch_created_by_user")
   event_reports_created    event_reports[]                 @relation("event_report_created_by")
   event_reports_updated    event_reports[]                 @relation("event_report_updated_by")
   event_reports_final_acted event_reports[]                @relation("event_report_final_acted_by")
@@ -471,6 +472,7 @@ model event_biometric_punch {
 model event_biometric_import_job {
   id                  Int                           @id @default(autoincrement())
   event_mgt_id        Int
+  source_stage_batch_id Int?
   occurrence_date     DateTime
   dry_run             Boolean                       @default(false)
   status              biometric_import_job_status   @default(QUEUED)
@@ -489,10 +491,58 @@ model event_biometric_import_job {
   updated_at          DateTime                      @updatedAt
   event               event_mgt                     @relation(fields: [event_mgt_id], references: [id])
   created_by_user     user                          @relation("event_biometric_import_job_created_by_user", fields: [created_by], references: [id])
+  source_stage_batch  event_biometric_stage_batch? @relation(fields: [source_stage_batch_id], references: [id])
 
   @@index([event_mgt_id, occurrence_date], map: "event_biometric_import_job_event_date_idx")
   @@index([status, created_at], map: "event_biometric_import_job_status_created_idx")
   @@index([created_by, created_at], map: "event_biometric_import_job_created_by_time_idx")
+  @@index([source_stage_batch_id], map: "event_biometric_import_job_stage_batch_idx")
+}
+
+model event_biometric_stage_batch {
+  id             Int                           @id @default(autoincrement())
+  status         biometric_import_job_status   @default(QUEUED)
+  source         String                        @default("ZTECO_LIBRARY")
+  total_punches  Int                           @default(0)
+  staged_punches Int                           @default(0)
+  duplicate_punches Int                        @default(0)
+  event_count    Int                           @default(0)
+  request_payload Json
+  result_payload Json?
+  error_message  String?                       @db.Text
+  created_by     Int
+  created_by_name String
+  created_at     DateTime                      @default(now())
+  started_at     DateTime?
+  completed_at   DateTime?
+  failed_at      DateTime?
+  updated_at     DateTime                      @updatedAt
+  created_by_user user                         @relation("event_biometric_stage_batch_created_by_user", fields: [created_by], references: [id])
+  punches        event_biometric_stage_punch[]
+  import_jobs    event_biometric_import_job[]
+
+  @@index([status, created_at], map: "event_biometric_stage_batch_status_created_idx")
+  @@index([created_by, created_at], map: "event_biometric_stage_batch_created_by_time_idx")
+}
+
+model event_biometric_stage_punch {
+  id                Int                          @id @default(autoincrement())
+  batch_id          Int
+  device_id         Int?
+  device_ip         String
+  device_port       String?
+  device_user_id    String
+  device_user_name  String?
+  record_time       DateTime
+  state             Int                          @default(-1)
+  source_fingerprint String
+  raw_payload       Json
+  created_at        DateTime                     @default(now())
+  batch             event_biometric_stage_batch  @relation(fields: [batch_id], references: [id], onDelete: Cascade)
+
+  @@unique([batch_id, source_fingerprint], map: "event_biometric_stage_punch_batch_fingerprint_key")
+  @@index([batch_id, record_time], map: "event_biometric_stage_punch_batch_time_idx")
+  @@index([device_ip, record_time], map: "event_biometric_stage_punch_device_time_idx")
 }
 
 model event_registers {

--- a/src/modules/events/biometricAttendanceService.ts
+++ b/src/modules/events/biometricAttendanceService.ts
@@ -29,6 +29,41 @@ type ImportRequest = {
   lead_time_minutes?: unknown;
   dryRun?: unknown;
   dry_run?: unknown;
+  sourceStageBatchId?: unknown;
+  source_stage_batch_id?: unknown;
+  punches?: unknown;
+};
+
+type StagePunchInput = {
+  ip?: unknown;
+  device_ip?: unknown;
+  port?: unknown;
+  device_port?: unknown;
+  user_Id?: unknown;
+  user_id?: unknown;
+  userId?: unknown;
+  uid?: unknown;
+  userid?: unknown;
+  user_name?: unknown;
+  name?: unknown;
+  state?: unknown;
+  record_time?: unknown;
+  recordTime?: unknown;
+  timestamp?: unknown;
+  record_time_ms?: unknown;
+  [key: string]: unknown;
+};
+
+type ParsedStagePunch = {
+  device_id: number | null;
+  device_ip: string;
+  device_port: string | null;
+  device_user_id: string;
+  device_user_name: string | null;
+  record_time: Date;
+  state: number;
+  source_fingerprint: string;
+  raw_payload: Prisma.InputJsonValue;
 };
 
 type ResolvedDevice = {
@@ -245,34 +280,39 @@ export class EventBiometricAttendanceService {
   async createImportJob(request: ImportRequest, actor: ImportActor) {
     const context = await this.resolveImportContext(request, actor);
     const occurrenceDate = this.toOccurrenceDate(context.window.occurrenceDate);
+    const sourceStageBatchId = this.toPositiveInt(
+      request?.sourceStageBatchId ?? request?.source_stage_batch_id,
+    );
 
-    const existingJob = await prisma.event_biometric_import_job.findFirst({
-      where: {
-        event_mgt_id: context.event.id,
-        occurrence_date: occurrenceDate,
-        dry_run: context.dryRun,
-        status: {
-          in: [
-            biometric_import_job_status.QUEUED,
-            biometric_import_job_status.RUNNING,
-          ],
-        },
-      },
-      include: {
-        event: {
-          select: {
+    const existingJob = sourceStageBatchId
+      ? null
+      : await prisma.event_biometric_import_job.findFirst({
+          where: {
+            event_mgt_id: context.event.id,
+            occurrence_date: occurrenceDate,
+            dry_run: context.dryRun,
+            status: {
+              in: [
+                biometric_import_job_status.QUEUED,
+                biometric_import_job_status.RUNNING,
+              ],
+            },
+          },
+          include: {
             event: {
               select: {
-                event_name: true,
+                event: {
+                  select: {
+                    event_name: true,
+                  },
+                },
               },
             },
           },
-        },
-      },
-      orderBy: {
-        created_at: "desc",
-      },
-    });
+          orderBy: {
+            created_at: "desc",
+          },
+        });
 
     if (existingJob) {
       if (
@@ -291,6 +331,8 @@ export class EventBiometricAttendanceService {
       date: context.window.occurrenceDate,
       dryRun: context.dryRun,
       leadTimeMinutes: context.window.leadTimeMinutes,
+      sourceStageBatchId,
+      source_stage_batch_id: sourceStageBatchId,
     });
 
     const job = await prisma.event_biometric_import_job.create({
@@ -305,6 +347,7 @@ export class EventBiometricAttendanceService {
         request_payload: requestPayload,
         created_by: context.actorUser.id,
         created_by_name: context.actorUser.name,
+        source_stage_batch_id: sourceStageBatchId,
       },
       include: {
         event: {
@@ -342,6 +385,118 @@ export class EventBiometricAttendanceService {
     }
 
     return jobs;
+  }
+
+  async stageAttendanceBatch(request: ImportRequest, actor: ImportActor) {
+    const actorUser = await this.requireActorUser(actor);
+    const eventIds = this.resolveRequestedEventIds(request);
+    const devices = await this.resolveDevices(request);
+    const parsedPunches = this.parseStagePunchInputs(request?.punches, devices);
+
+    if (!parsedPunches.totalCount) {
+      throw new EventBiometricAttendanceImportError(
+        "At least one attendance punch is required for staging",
+      );
+    }
+
+    if (!parsedPunches.punches.length) {
+      throw new EventBiometricAttendanceImportError(
+        "No valid attendance punches were found in the staging payload",
+      );
+    }
+
+    const requestPayload = this.toJsonPayload({
+      eventIds,
+      date: request?.date,
+      dryRun: this.toBoolean(request?.dryRun ?? request?.dry_run),
+      leadTimeMinutes:
+        this.toPositiveInt(
+          request?.leadTimeMinutes ?? request?.lead_time_minutes,
+        ) || this.defaultLeadTimeMinutes,
+      deviceIds: devices
+        .map((device) => device.id)
+        .filter((deviceId): deviceId is number => deviceId !== null),
+      devices: devices.map((device) => ({
+        id: device.id,
+        ip: device.ip,
+        port: device.port,
+      })),
+      totals: {
+        received: parsedPunches.totalCount,
+        unique: parsedPunches.punches.length,
+        duplicates: parsedPunches.duplicateCount,
+      },
+    });
+
+    const batch = await prisma.$transaction(async (tx) => {
+      const createdBatch = await tx.event_biometric_stage_batch.create({
+        data: {
+          status: biometric_import_job_status.RUNNING,
+          source: "ZTECO_LIBRARY",
+          total_punches: parsedPunches.totalCount,
+          staged_punches: parsedPunches.punches.length,
+          duplicate_punches: parsedPunches.duplicateCount,
+          event_count: eventIds.length,
+          request_payload: requestPayload,
+          created_by: actorUser.id,
+          created_by_name: actorUser.name,
+          started_at: new Date(),
+        },
+      });
+
+      await this.persistStagePunches(
+        tx,
+        createdBatch.id,
+        parsedPunches.punches,
+      );
+
+      const jobs: ImportJobSnapshot[] = [];
+      for (const eventId of eventIds) {
+        const job = await this.createImportJobWithClient(
+          tx,
+          {
+            ...request,
+            eventId,
+            event_id: eventId,
+            deviceIds: devices
+              .map((device) => device.id)
+              .filter((deviceId): deviceId is number => deviceId !== null),
+            devices: devices.map((device) => ({
+              id: device.id,
+              ip: device.ip,
+              port: device.port,
+            })),
+            sourceStageBatchId: createdBatch.id,
+            source_stage_batch_id: createdBatch.id,
+          },
+          actorUser,
+        );
+
+        jobs.push(job);
+      }
+
+      await tx.event_biometric_stage_batch.update({
+        where: { id: createdBatch.id },
+        data: {
+          status: biometric_import_job_status.COMPLETED,
+          completed_at: new Date(),
+          result_payload: this.toJsonPayload({
+            job_ids: jobs.map((job) => job.id),
+          }),
+        },
+      });
+
+      return {
+        id: createdBatch.id,
+        jobs,
+      };
+    });
+
+    for (const job of batch.jobs) {
+      this.startImportJob(job.id);
+    }
+
+    return batch;
   }
 
   async getImportJob(jobId: number) {
@@ -389,6 +544,56 @@ export class EventBiometricAttendanceService {
       },
       context,
     );
+  }
+
+  private async createImportJobWithClient(
+    tx: Prisma.TransactionClient,
+    request: ImportRequest,
+    actorUser: { id: number; name: string },
+  ) {
+    const context = await this.resolveImportContext(request, { id: actorUser.id });
+    const occurrenceDate = this.toOccurrenceDate(context.window.occurrenceDate);
+    const sourceStageBatchId = this.toPositiveInt(
+      request?.sourceStageBatchId ?? request?.source_stage_batch_id,
+    );
+    const requestPayload = this.toJsonPayload({
+      ...request,
+      eventId: context.event.id,
+      date: context.window.occurrenceDate,
+      dryRun: context.dryRun,
+      leadTimeMinutes: context.window.leadTimeMinutes,
+      sourceStageBatchId,
+      source_stage_batch_id: sourceStageBatchId,
+    });
+
+    const job = await tx.event_biometric_import_job.create({
+      data: {
+        event_mgt_id: context.event.id,
+        occurrence_date: occurrenceDate,
+        dry_run: context.dryRun,
+        status: biometric_import_job_status.QUEUED,
+        progress_percentage: 0,
+        current_step: "Queued",
+        progress_payload: this.toJsonPayload(this.createEmptyProgress()),
+        request_payload: requestPayload,
+        created_by: actorUser.id,
+        created_by_name: actorUser.name,
+        source_stage_batch_id: sourceStageBatchId,
+      },
+      include: {
+        event: {
+          select: {
+            event: {
+              select: {
+                event_name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return this.mapImportJob(job);
   }
 
   private startImportJob(jobId: number) {
@@ -534,20 +739,7 @@ export class EventBiometricAttendanceService {
       throw new EventBiometricAttendanceImportError("Event not found", 404);
     }
 
-    const actorUser = await prisma.user.findUnique({
-      where: { id: actor.id },
-      select: {
-        id: true,
-        name: true,
-      },
-    });
-
-    if (!actorUser) {
-      throw new EventBiometricAttendanceImportError(
-        "Authenticated user not found",
-        401,
-      );
-    }
+    const actorUser = await this.requireActorUser(actor);
 
     const leadTimeMinutes =
       this.toPositiveInt(
@@ -563,6 +755,25 @@ export class EventBiometricAttendanceService {
       actorUser,
       window,
     };
+  }
+
+  private async requireActorUser(actor: ImportActor) {
+    const actorUser = await prisma.user.findUnique({
+      where: { id: actor.id },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    if (!actorUser) {
+      throw new EventBiometricAttendanceImportError(
+        "Authenticated user not found",
+        401,
+      );
+    }
+
+    return actorUser;
   }
 
   private resolveRequestedEventIds(request: ImportRequest) {
@@ -596,6 +807,9 @@ export class EventBiometricAttendanceService {
     const context =
       resolvedContext || (await this.resolveImportContext(request, actor));
     const { dryRun, event, actorUser, window } = context;
+    const sourceStageBatchId = this.toPositiveInt(
+      request?.sourceStageBatchId ?? request?.source_stage_batch_id,
+    );
 
     await reportProgress?.({
       percentage: 10,
@@ -606,20 +820,28 @@ export class EventBiometricAttendanceService {
 
     await reportProgress?.({
       percentage: 15,
-      step: `Fetching punches from ${devices.length} device${
-        devices.length === 1 ? "" : "s"
-      }`,
+      step: sourceStageBatchId
+        ? "Loading staged punches"
+        : `Fetching punches from ${devices.length} device${
+            devices.length === 1 ? "" : "s"
+          }`,
       patch: {
         total_devices: devices.length,
         processed_devices: 0,
       },
     });
 
-    const rawPunches = await this.fetchPunchesFromZteco(
-      devices,
-      window,
-      reportProgress,
-    );
+    const rawPunches = sourceStageBatchId
+      ? await this.fetchPunchesFromStageBatch(
+          sourceStageBatchId,
+          devices,
+          reportProgress,
+        )
+      : await this.fetchPunchesFromZteco(
+          devices,
+          window,
+          reportProgress,
+        );
     const matcher = await this.buildUserMatcher();
 
     await reportProgress?.({
@@ -1088,6 +1310,97 @@ export class EventBiometricAttendanceService {
       .filter((device): device is ResolvedDevice => Boolean(device));
   }
 
+  private parseStagePunchInputs(
+    value: unknown,
+    devices: ResolvedDevice[],
+  ): {
+    totalCount: number;
+    duplicateCount: number;
+    punches: ParsedStagePunch[];
+  } {
+    if (!Array.isArray(value)) {
+      return {
+        totalCount: 0,
+        duplicateCount: 0,
+        punches: [],
+      };
+    }
+
+    const deviceByIp = new Map<string, ResolvedDevice>();
+    for (const device of devices) {
+      deviceByIp.set(device.ip, device);
+    }
+
+    const punchesByFingerprint = new Map<string, ParsedStagePunch>();
+    let duplicateCount = 0;
+
+    for (const rawPunch of value) {
+      if (!rawPunch || typeof rawPunch !== "object" || Array.isArray(rawPunch)) {
+        continue;
+      }
+
+      const typedPunch = rawPunch as StagePunchInput;
+      const deviceIp = this.normalizeText(
+        typedPunch.device_ip ?? typedPunch.ip,
+      );
+      const deviceUserId = this.normalizeText(
+        typedPunch.user_Id ??
+          typedPunch.user_id ??
+          typedPunch.userId ??
+          typedPunch.uid ??
+          typedPunch.userid,
+      );
+      const recordTime = this.parseRecordTime(
+        typedPunch as unknown as Record<string, unknown>,
+      );
+      const parsedState = Number(typedPunch.state);
+
+      if (!deviceIp || !deviceUserId || !recordTime) {
+        continue;
+      }
+
+      const fingerprint = this.buildStagePunchFingerprint({
+        device_ip: deviceIp,
+        device_user_id: deviceUserId,
+        record_time: recordTime,
+        state: Number.isFinite(parsedState) ? Math.trunc(parsedState) : -1,
+      });
+      const device = deviceByIp.get(deviceIp);
+      const parsedPunch: ParsedStagePunch = {
+        device_id: device?.id ?? null,
+        device_ip: deviceIp,
+        device_port:
+          device?.port !== null && device?.port !== undefined
+            ? String(device.port)
+            : this.normalizeNullableText(
+                typedPunch.device_port ?? typedPunch.port,
+              ),
+        device_user_id: deviceUserId,
+        device_user_name: this.normalizeNullableText(
+          typedPunch.user_name ?? typedPunch.name,
+        ),
+        record_time: recordTime,
+        state: Number.isFinite(parsedState) ? Math.trunc(parsedState) : -1,
+        source_fingerprint: fingerprint,
+        raw_payload: this.toJsonPayload(typedPunch),
+      };
+
+      if (punchesByFingerprint.has(fingerprint)) {
+        duplicateCount += 1;
+      }
+
+      punchesByFingerprint.set(fingerprint, parsedPunch);
+    }
+
+    return {
+      totalCount: value.length,
+      duplicateCount,
+      punches: Array.from(punchesByFingerprint.values()).sort(
+        (left, right) => left.record_time.getTime() - right.record_time.getTime(),
+      ),
+    };
+  }
+
   private parsePositiveIntArray(value: unknown): number[] {
     if (!Array.isArray(value)) return [];
 
@@ -1098,6 +1411,20 @@ export class EventBiometricAttendanceService {
           .filter((entry): entry is number => Boolean(entry)),
       ),
     );
+  }
+
+  private buildStagePunchFingerprint(punch: {
+    device_ip: string;
+    device_user_id: string;
+    record_time: Date;
+    state: number;
+  }) {
+    return [
+      punch.device_ip,
+      punch.device_user_id,
+      punch.record_time.toISOString(),
+      punch.state,
+    ].join(":");
   }
 
   private async resolveDevices(request: ImportRequest): Promise<ResolvedDevice[]> {
@@ -1184,6 +1511,61 @@ export class EventBiometricAttendanceService {
     }
 
     return allPunches;
+  }
+
+  private async fetchPunchesFromStageBatch(
+    batchId: number,
+    devices: ResolvedDevice[],
+    reportProgress?: ImportProgressReporter,
+  ): Promise<Record<string, unknown>[]> {
+    const deviceIps = Array.from(
+      new Set(devices.map((device) => device.ip).filter(Boolean)),
+    );
+
+    const punches = await prisma.event_biometric_stage_punch.findMany({
+      where: {
+        batch_id: batchId,
+        ...(deviceIps.length
+          ? {
+              device_ip: {
+                in: deviceIps,
+              },
+            }
+          : {}),
+      },
+      orderBy: {
+        record_time: "asc",
+      },
+      select: {
+        raw_payload: true,
+      },
+    });
+
+    await reportProgress?.({
+      percentage: 45,
+      step: `Loaded ${punches.length} staged punch${
+        punches.length === 1 ? "" : "es"
+      }`,
+      patch: {
+        total_devices: devices.length,
+        processed_devices: devices.length,
+        raw_punches_fetched: punches.length,
+      },
+    });
+
+    return punches
+      .map((punch) => {
+        if (
+          punch.raw_payload &&
+          typeof punch.raw_payload === "object" &&
+          !Array.isArray(punch.raw_payload)
+        ) {
+          return punch.raw_payload as Record<string, unknown>;
+        }
+
+        return null;
+      })
+      .filter((punch): punch is Record<string, unknown> => Boolean(punch));
   }
 
   private async fetchPunchesForDevice(
@@ -1469,6 +1851,34 @@ export class EventBiometricAttendanceService {
       createdCount: createResult.count,
       upgradedMatchCount,
     };
+  }
+
+  private async persistStagePunches(
+    tx: Prisma.TransactionClient,
+    batchId: number,
+    punches: ParsedStagePunch[],
+  ) {
+    if (!punches.length) return;
+
+    const chunkSize = 500;
+    for (let index = 0; index < punches.length; index += chunkSize) {
+      const chunk = punches.slice(index, index + chunkSize);
+      await tx.event_biometric_stage_punch.createMany({
+        data: chunk.map((punch) => ({
+          batch_id: batchId,
+          device_id: punch.device_id,
+          device_ip: punch.device_ip,
+          device_port: punch.device_port,
+          device_user_id: punch.device_user_id,
+          device_user_name: punch.device_user_name,
+          record_time: punch.record_time,
+          state: punch.state,
+          source_fingerprint: punch.source_fingerprint,
+          raw_payload: punch.raw_payload,
+        })),
+        skipDuplicates: true,
+      });
+    }
   }
 
   private buildAttendanceCandidates(

--- a/src/modules/events/eventContoller.ts
+++ b/src/modules/events/eventContoller.ts
@@ -3275,6 +3275,53 @@ export class eventManagement {
     }
   };
 
+  stageBiometricAttendance = async (req: Request, res: Response) => {
+    try {
+      const actorUserId = this.getActorUserId(req);
+      if (!actorUserId) {
+        return res.status(401).json({
+          success: false,
+          message: "A valid authenticated user is required",
+        });
+      }
+
+      const batch = await biometricAttendanceService.stageAttendanceBatch(
+        req.body,
+        {
+          id: actorUserId,
+        },
+      );
+      const responseData = batch.jobs.length === 1 ? batch.jobs[0] : batch.jobs;
+
+      return res.status(202).json({
+        success: true,
+        message:
+          batch.jobs.length === 1
+            ? "Biometric attendance staging batch accepted"
+            : "Biometric attendance staging batch accepted",
+        data: responseData,
+        batch_id: batch.id,
+      });
+    } catch (error: any) {
+      const statusCode =
+        error instanceof EventBiometricAttendanceImportError
+          ? error.statusCode
+          : 500;
+
+      return res.status(statusCode).json({
+        success: false,
+        message:
+          error instanceof EventBiometricAttendanceImportError
+            ? error.message
+            : "Unable to stage biometric attendance",
+        data:
+          error instanceof EventBiometricAttendanceImportError
+            ? null
+            : error?.message || null,
+      });
+    }
+  };
+
   getBiometricAttendanceImportJob = async (req: Request, res: Response) => {
     try {
       const jobId = this.toPositiveInt(req.query?.id);

--- a/src/modules/events/eventRoute.ts
+++ b/src/modules/events/eventRoute.ts
@@ -124,6 +124,12 @@ eventRouter.get(
 );
 
 eventRouter.post(
+  "/stage-biometric-attendance",
+  [protect, permissions.can_manage_church_attendance],
+  eventContoller.stageBiometricAttendance,
+);
+
+eventRouter.post(
   "/import-biometric-attendance",
   [protect, permissions.can_manage_church_attendance],
   eventContoller.importBiometricAttendance,

--- a/src/modules/user/userController.ts
+++ b/src/modules/user/userController.ts
@@ -1194,6 +1194,70 @@ export const deleteUser = async (req: Request, res: Response) => {
   }
 };
 
+export const deleteOwnAccount = async (req: Request, res: Response) => {
+  const authenticatedUserId = Number((req as any).user?.id);
+  if (!Number.isInteger(authenticatedUserId) || authenticatedUserId <= 0) {
+    return res.status(401).json({ message: "Unauthorized", data: null });
+  }
+
+  try {
+    const existingUser = await prisma.user.findUnique({
+      where: { id: authenticatedUserId },
+      select: { id: true },
+    });
+
+    if (!existingUser) {
+      return res.status(404).json({ message: "User not found", data: null });
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.notification_push_subscription.updateMany({
+        where: { user_id: authenticatedUserId },
+        data: { is_active: false },
+      });
+
+      await tx.user_info.updateMany({
+        where: { user_id: authenticatedUserId },
+        data: {
+          first_name: null,
+          last_name: null,
+          other_name: null,
+          primary_number: null,
+          other_number: null,
+          email: null,
+          address: null,
+          city: null,
+          state_region: null,
+          occupation: null,
+          company: null,
+          photo: null,
+          payment_info_token: null,
+        },
+      });
+
+      await tx.user.update({
+        where: { id: authenticatedUserId },
+        data: {
+          name: `Deleted User ${authenticatedUserId}`,
+          email: null,
+          password: null,
+          is_active: false,
+          is_user: false,
+          updated_at: new Date(),
+        },
+      });
+    });
+
+    return res
+      .status(200)
+      .json({ message: "Account deleted successfully", data: null });
+  } catch (error: any) {
+    return res
+      .status(500)
+      .json({ message: "Internal Server Error", data: null });
+  }
+};
+
 export const login = async (req: Request, res: Response) => {
   const { email, password } = req.body;
   try {

--- a/src/modules/user/userRoutes.ts
+++ b/src/modules/user/userRoutes.ts
@@ -4,6 +4,7 @@ import {
   ListUsers,
   changePassword,
   deleteUser,
+  deleteOwnAccount,
   forgetPassword,
   getUser,
   landingPage,
@@ -84,6 +85,9 @@ userRouter.delete(
   [protect, permissions.can_delete_member_details],
   deleteUser,
 );
+
+userRouter.delete("/delete-account", [protect], deleteOwnAccount);
+
 userRouter.put(
   "/activate-account",
   [protect, permissions.can_manage_member_details],


### PR DESCRIPTION
Add support for staging biometric attendance batches and storing staged punches, plus an endpoint for users to delete their own account. Changes include:

- Increase request body size limits from 1MB to 25MB in index.ts to allow large biometric payloads.
- Add a new Prisma migration (20260513120000_add_biometric_stage_batches) creating event_biometric_stage_batch and event_biometric_stage_punch tables, indexes, and foreign keys; add source_stage_batch_id to event_biometric_import_job.
- Update prisma/schema.prisma with models and relations for stage batches and stage punches and index for source_stage_batch_id.
- Extend EventBiometricAttendanceService with: parsing of staged punch inputs, staging API (stageAttendanceBatch), persisting staged punches, fetching punches from a stage batch, creating import jobs that reference a stage batch, and helper utilities (fingerprint builder, actor user resolver). Also adjust existing import flow to optionally use staged batches.
- Add controller method stageBiometricAttendance and register POST /stage-biometric-attendance route with appropriate protection/permissions.
- Add deleteOwnAccount controller and register DELETE /delete-account route to anonymize and deactivate a user's data (disable push subscriptions, clear user_info, clear credentials and mark inactive) within a transaction.

These changes enable staged imports of biometric data, link staged batches to import jobs, and provide a safe account deletion endpoint.