### PR TITLE
Add S3 upload/import for biometric attendance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@aws-sdk/client-s3": "^3.1029.0",
+        "@aws-sdk/s3-request-presigner": "^3.1045.0",
         "@google/genai": "^1.43.0",
         "@prisma/client": "^6.12.0",
         "@types/cors": "^2.8.13",
@@ -397,22 +398,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -709,23 +711,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.28.tgz",
-      "integrity": "sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -831,17 +833,36 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.16.tgz",
-      "integrity": "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1045.0.tgz",
+      "integrity": "sha512-VDRF8GIuUPX+K4DUYrvcODj/h54LOmdJ7DhpLQ0wrYrdxzIiJEpi0n9jZ1bbjT2UxhwTbOorse5EGo+gnOK2aA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -867,12 +888,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -901,6 +922,21 @@
         "@smithy/types": "^4.14.0",
         "@smithy/url-parser": "^4.2.13",
         "@smithy/util-endpoints": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -957,13 +993,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1296,6 +1333,18 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@npmcli/agent": {
       "version": "2.2.2",
@@ -1642,20 +1691,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.14",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
-      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
+      "integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1862,18 +1904,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
-      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.1.tgz",
+      "integrity": "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1930,14 +1966,12 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
-      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.1.tgz",
+      "integrity": "sha512-q7tDJEJXcaSG/8TVpu2f2l9bzxTzDM9geWmltbzsY6Hfh3yiuXXTpLIO8+zwYASPPVFaTJpdKwjSSjdoDoccgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1960,12 +1994,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
-      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.3.1.tgz",
+      "integrity": "sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1973,12 +2007,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.1.tgz",
+      "integrity": "sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1986,13 +2020,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
-      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.3.1.tgz",
+      "integrity": "sha512-toyi8sXPWDNoVH6yK7sXJ9dm5uxw2tWLCHzPy/t16Fvl62Es4vXQXzlilyNaw+DqFwxSlrFClh0rGLPUF2p9Lg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2038,18 +2071,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.1.tgz",
+      "integrity": "sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2057,17 +2085,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
-      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.1.tgz",
+      "integrity": "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2075,9 +2099,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2223,12 +2247,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
-      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.3.1.tgz",
+      "integrity": "sha512-SRRMDcIgVXVhVbxviBaSZbuWuVW3jD08wv4ESV0V2oiw0Mki8TPVQ5IxwD3MvSTPg52QYsRP+JoMw5WdUdeWAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2236,13 +2260,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
-      "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.1.tgz",
+      "integrity": "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2250,30 +2273,12 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
-      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.6.1.tgz",
+      "integrity": "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4975,9 +4980,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -4986,13 +4991,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -5001,9 +5007,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9758,9 +9765,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -10913,6 +10920,21 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@aws-sdk/client-s3": "^3.1029.0",
+    "@aws-sdk/s3-request-presigner": "^3.1045.0",
     "@google/genai": "^1.43.0",
     "@prisma/client": "^6.12.0",
     "@types/cors": "^2.8.13",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -491,7 +491,7 @@ model event_biometric_import_job {
   updated_at          DateTime                      @updatedAt
   event               event_mgt                     @relation(fields: [event_mgt_id], references: [id])
   created_by_user     user                          @relation("event_biometric_import_job_created_by_user", fields: [created_by], references: [id])
-  source_stage_batch  event_biometric_stage_batch? @relation(fields: [source_stage_batch_id], references: [id])
+  source_stage_batch  event_biometric_stage_batch?  @relation(fields: [source_stage_batch_id], references: [id])
 
   @@index([event_mgt_id, occurrence_date], map: "event_biometric_import_job_event_date_idx")
   @@index([status, created_at], map: "event_biometric_import_job_status_created_idx")
@@ -500,45 +500,45 @@ model event_biometric_import_job {
 }
 
 model event_biometric_stage_batch {
-  id             Int                           @id @default(autoincrement())
-  status         biometric_import_job_status   @default(QUEUED)
-  source         String                        @default("ZTECO_LIBRARY")
-  total_punches  Int                           @default(0)
-  staged_punches Int                           @default(0)
+  id               Int                         @id @default(autoincrement())
+  status           biometric_import_job_status @default(QUEUED)
+  source           String                      @default("ZTECO_LIBRARY")
+  total_punches    Int                         @default(0)
+  staged_punches   Int                         @default(0)
   duplicate_punches Int                        @default(0)
-  event_count    Int                           @default(0)
-  request_payload Json
-  result_payload Json?
-  error_message  String?                       @db.Text
-  created_by     Int
-  created_by_name String
-  created_at     DateTime                      @default(now())
-  started_at     DateTime?
-  completed_at   DateTime?
-  failed_at      DateTime?
-  updated_at     DateTime                      @updatedAt
-  created_by_user user                         @relation("event_biometric_stage_batch_created_by_user", fields: [created_by], references: [id])
-  punches        event_biometric_stage_punch[]
-  import_jobs    event_biometric_import_job[]
+  event_count      Int                         @default(0)
+  request_payload  Json
+  result_payload   Json?
+  error_message    String?                     @db.Text
+  created_by       Int
+  created_by_name  String
+  created_at       DateTime                    @default(now())
+  started_at       DateTime?
+  completed_at     DateTime?
+  failed_at        DateTime?
+  updated_at       DateTime                    @updatedAt
+  created_by_user  user                        @relation("event_biometric_stage_batch_created_by_user", fields: [created_by], references: [id])
+  punches          event_biometric_stage_punch[]
+  import_jobs      event_biometric_import_job[]
 
   @@index([status, created_at], map: "event_biometric_stage_batch_status_created_idx")
   @@index([created_by, created_at], map: "event_biometric_stage_batch_created_by_time_idx")
 }
 
 model event_biometric_stage_punch {
-  id                Int                          @id @default(autoincrement())
-  batch_id          Int
-  device_id         Int?
-  device_ip         String
-  device_port       String?
-  device_user_id    String
-  device_user_name  String?
-  record_time       DateTime
-  state             Int                          @default(-1)
+  id                 Int                          @id @default(autoincrement())
+  batch_id           Int
+  device_id          Int?
+  device_ip          String
+  device_port        String?
+  device_user_id     String
+  device_user_name   String?
+  record_time        DateTime
+  state              Int                          @default(-1)
   source_fingerprint String
-  raw_payload       Json
-  created_at        DateTime                     @default(now())
-  batch             event_biometric_stage_batch  @relation(fields: [batch_id], references: [id], onDelete: Cascade)
+  raw_payload        Json
+  created_at         DateTime                     @default(now())
+  batch              event_biometric_stage_batch  @relation(fields: [batch_id], references: [id], onDelete: Cascade)
 
   @@unique([batch_id, source_fingerprint], map: "event_biometric_stage_punch_batch_fingerprint_key")
   @@index([batch_id, record_time], map: "event_biometric_stage_punch_batch_time_idx")

--- a/src/modules/events/biometricAttendanceService.ts
+++ b/src/modules/events/biometricAttendanceService.ts
@@ -2,6 +2,12 @@ import axios from "axios";
 import { Prisma, biometric_import_job_status } from "@prisma/client";
 import { prisma } from "../../Models/context";
 import {
+  buildS3ObjectKey,
+  createPresignedUploadUrl,
+  downloadJsonObjectFromS3,
+  getConfiguredS3BucketName,
+} from "../../utils";
+import {
   buildZtecoServiceRequestConfig,
   getZtecoServiceUrl,
 } from "../integrationUtils/ztecoServiceClient";
@@ -32,6 +38,12 @@ type ImportRequest = {
   sourceStageBatchId?: unknown;
   source_stage_batch_id?: unknown;
   punches?: unknown;
+  uploadKey?: unknown;
+  upload_key?: unknown;
+  punchCount?: unknown;
+  punch_count?: unknown;
+  payloadBytes?: unknown;
+  payload_bytes?: unknown;
 };
 
 type StagePunchInput = {
@@ -387,6 +399,95 @@ export class EventBiometricAttendanceService {
     return jobs;
   }
 
+  async createS3UploadIntent(request: ImportRequest, actor: ImportActor) {
+    const actorUser = await this.requireActorUser(actor);
+    const eventIds = this.resolveRequestedEventIds(request);
+    const devices = await this.resolveDevices(request);
+    const now = new Date();
+    const folder = [
+      "biometric-attendance",
+      "raw",
+      String(now.getUTCFullYear()),
+      String(now.getUTCMonth() + 1).padStart(2, "0"),
+      String(now.getUTCDate()).padStart(2, "0"),
+    ].join("/");
+    const punchCount = this.toNonNegativeInt(
+      request?.punchCount ?? request?.punch_count,
+    );
+    const payloadBytes = this.toNonNegativeInt(
+      request?.payloadBytes ?? request?.payload_bytes,
+    );
+    const objectKey = buildS3ObjectKey({
+      folder,
+      baseName: `attendance-${actorUser.id}-${eventIds.length}events-${Math.max(
+        punchCount,
+        1,
+      )}punches`,
+      contentType: "application/json",
+    });
+    const upload = await createPresignedUploadUrl({
+      key: objectKey,
+      contentType: "application/json",
+      expiresInSeconds: 900,
+    });
+
+    return {
+      bucket: getConfiguredS3BucketName(),
+      key: upload.key,
+      upload_url: upload.uploadUrl,
+      object_url: upload.publicUrl,
+      method: upload.method,
+      content_type: upload.contentType,
+      expires_in_seconds: upload.expiresInSeconds,
+      event_count: eventIds.length,
+      device_count: devices.length,
+      punch_count: punchCount,
+      payload_bytes: payloadBytes,
+    };
+  }
+
+  async importAttendanceFromUploadedFile(
+    request: ImportRequest,
+    actor: ImportActor,
+  ) {
+    const uploadKey = this.normalizeText(request?.uploadKey ?? request?.upload_key);
+    if (!uploadKey) {
+      throw new EventBiometricAttendanceImportError("uploadKey is required");
+    }
+
+    const uploadedPayload = await downloadJsonObjectFromS3<{
+      punches?: unknown;
+    }>(uploadKey);
+    const punches = Array.isArray((uploadedPayload as any)?.punches)
+      ? (uploadedPayload as any).punches
+      : Array.isArray(uploadedPayload)
+        ? uploadedPayload
+        : null;
+
+    if (!punches) {
+      throw new EventBiometricAttendanceImportError(
+        "Uploaded attendance payload is invalid",
+      );
+    }
+
+    const expectedPunchCount = this.toNonNegativeInt(
+      request?.punchCount ?? request?.punch_count,
+    );
+    if (expectedPunchCount > 0 && punches.length !== expectedPunchCount) {
+      throw new EventBiometricAttendanceImportError(
+        "Uploaded attendance payload does not match the expected punch count",
+      );
+    }
+
+    return this.stageAttendanceBatch(
+      {
+        ...request,
+        punches,
+      },
+      actor,
+    );
+  }
+
   async stageAttendanceBatch(request: ImportRequest, actor: ImportActor) {
     const actorUser = await this.requireActorUser(actor);
     const eventIds = this.resolveRequestedEventIds(request);
@@ -426,6 +527,7 @@ export class EventBiometricAttendanceService {
         unique: parsedPunches.punches.length,
         duplicates: parsedPunches.duplicateCount,
       },
+      upload_key: this.normalizeText(request?.uploadKey ?? request?.upload_key) || null,
     });
 
     const batch = await prisma.$transaction(async (tx) => {

--- a/src/modules/events/eventContoller.ts
+++ b/src/modules/events/eventContoller.ts
@@ -3295,10 +3295,7 @@ export class eventManagement {
 
       return res.status(202).json({
         success: true,
-        message:
-          batch.jobs.length === 1
-            ? "Biometric attendance staging batch accepted"
-            : "Biometric attendance staging batch accepted",
+        message: "Biometric attendance staging batch accepted",
         data: responseData,
         batch_id: batch.id,
       });
@@ -3314,6 +3311,98 @@ export class eventManagement {
           error instanceof EventBiometricAttendanceImportError
             ? error.message
             : "Unable to stage biometric attendance",
+        data:
+          error instanceof EventBiometricAttendanceImportError
+            ? null
+            : error?.message || null,
+      });
+    }
+  };
+
+  createBiometricAttendanceUploadIntent = async (
+    req: Request,
+    res: Response,
+  ) => {
+    try {
+      const actorUserId = this.getActorUserId(req);
+      if (!actorUserId) {
+        return res.status(401).json({
+          success: false,
+          message: "A valid authenticated user is required",
+        });
+      }
+
+      const uploadIntent = await biometricAttendanceService.createS3UploadIntent(
+        req.body,
+        {
+          id: actorUserId,
+        },
+      );
+
+      return res.status(200).json({
+        success: true,
+        message: "Biometric attendance upload intent created successfully",
+        data: uploadIntent,
+      });
+    } catch (error: any) {
+      const statusCode =
+        error instanceof EventBiometricAttendanceImportError
+          ? error.statusCode
+          : 500;
+
+      return res.status(statusCode).json({
+        success: false,
+        message:
+          error instanceof EventBiometricAttendanceImportError
+            ? error.message
+            : "Unable to create biometric attendance upload intent",
+        data:
+          error instanceof EventBiometricAttendanceImportError
+            ? null
+            : error?.message || null,
+      });
+    }
+  };
+
+  importBiometricAttendanceFromUpload = async (
+    req: Request,
+    res: Response,
+  ) => {
+    try {
+      const actorUserId = this.getActorUserId(req);
+      if (!actorUserId) {
+        return res.status(401).json({
+          success: false,
+          message: "A valid authenticated user is required",
+        });
+      }
+
+      const batch = await biometricAttendanceService.importAttendanceFromUploadedFile(
+        req.body,
+        {
+          id: actorUserId,
+        },
+      );
+      const responseData = batch.jobs.length === 1 ? batch.jobs[0] : batch.jobs;
+
+      return res.status(202).json({
+        success: true,
+        message: "Biometric attendance import jobs started from uploaded batch",
+        data: responseData,
+        batch_id: batch.id,
+      });
+    } catch (error: any) {
+      const statusCode =
+        error instanceof EventBiometricAttendanceImportError
+          ? error.statusCode
+          : 500;
+
+      return res.status(statusCode).json({
+        success: false,
+        message:
+          error instanceof EventBiometricAttendanceImportError
+            ? error.message
+            : "Unable to import biometric attendance from uploaded batch",
         data:
           error instanceof EventBiometricAttendanceImportError
             ? null

--- a/src/modules/events/eventRoute.ts
+++ b/src/modules/events/eventRoute.ts
@@ -130,6 +130,18 @@ eventRouter.post(
 );
 
 eventRouter.post(
+  "/biometric-attendance-upload-intent",
+  [protect, permissions.can_manage_church_attendance],
+  eventContoller.createBiometricAttendanceUploadIntent,
+);
+
+eventRouter.post(
+  "/stage-biometric-attendance-from-upload",
+  [protect, permissions.can_manage_church_attendance],
+  eventContoller.importBiometricAttendanceFromUpload,
+);
+
+eventRouter.post(
   "/import-biometric-attendance",
   [protect, permissions.can_manage_church_attendance],
   eventContoller.importBiometricAttendance,

--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -1,8 +1,10 @@
 import {
   DeleteObjectCommand,
+  GetObjectCommand,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import path from "path";
@@ -110,6 +112,21 @@ const buildObjectKey = (args: {
   return [folder, filename].filter(Boolean).join("/");
 };
 
+const streamToString = async (body: unknown): Promise<string> => {
+  if (!body) return "";
+
+  if (typeof (body as any).transformToString === "function") {
+    return (body as any).transformToString();
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of body as AsyncIterable<Buffer | Uint8Array | string>) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+};
+
 type UploadBufferToS3Args = {
   buffer: Buffer;
   folder?: string;
@@ -136,6 +153,65 @@ export const uploadBufferToS3 = async (args: UploadBufferToS3Args) => {
     key,
     url: buildPublicUrl(key),
   };
+};
+
+type CreatePresignedUploadArgs = {
+  key: string;
+  contentType?: string;
+  expiresInSeconds?: number;
+};
+
+export const createPresignedUploadUrl = async (
+  args: CreatePresignedUploadArgs,
+) => {
+  ensureS3Config();
+
+  const expiresInSeconds = Math.max(
+    60,
+    Math.min(3600, Math.trunc(args.expiresInSeconds || 900)),
+  );
+  const uploadUrl = await getSignedUrl(
+    s3Client,
+    new PutObjectCommand({
+      Bucket: s3BucketName,
+      Key: args.key,
+      ContentType: args.contentType || undefined,
+    }),
+    {
+      expiresIn: expiresInSeconds,
+    },
+  );
+
+  return {
+    bucket: s3BucketName,
+    key: args.key,
+    uploadUrl,
+    publicUrl: buildPublicUrl(args.key),
+    expiresInSeconds,
+    contentType: args.contentType || "application/json",
+    method: "PUT" as const,
+  };
+};
+
+export const buildS3ObjectKey = buildObjectKey;
+
+export const getConfiguredS3BucketName = () => {
+  ensureS3Config();
+  return s3BucketName;
+};
+
+export const downloadJsonObjectFromS3 = async <T = unknown>(key: string) => {
+  ensureS3Config();
+
+  const response = await s3Client.send(
+    new GetObjectCommand({
+      Bucket: s3BucketName,
+      Key: key,
+    }),
+  );
+
+  const bodyText = await streamToString(response.Body);
+  return JSON.parse(bodyText) as T;
 };
 
 type UploadLocalFileToS3Args = {


### PR DESCRIPTION
Add presigned S3 upload flow and import support for biometric attendance files.

- Add @aws-sdk/s3-request-presigner to package.json and update package-lock with related dependency bumps.
- New s3 utility helpers: createPresignedUploadUrl, downloadJsonObjectFromS3, buildS3ObjectKey, getConfiguredS3BucketName, and streamToString; uses getSignedUrl to produce PUT upload URLs.
- Event service extended with createS3UploadIntent and importAttendanceFromUploadedFile to create upload intents and to stage attendance from an uploaded JSON payload (and minor payload fields handling).
- Controller and route changes: new endpoints for creating upload intent and importing staged uploads; updated responses and error handling.
- Prisma schema changes add fields to event_biometric_stage_batch and event_biometric_stage_punch to support metadata (counts, payloads, device/user fields). NOTE: prisma/schema.prisma contains unresolved merge conflict markers (<<<<<<< / ======= / >>>>>>>) that must be resolved before running migrations.

Run npm install to pick up new dependency and resolve the Prisma merge conflicts before applying schema migrations.