### PR TITLE
Add branch_id to finance config services

### DIFF
--- a/src/modules/finance/BankAccountConfig/service.ts
+++ b/src/modules/finance/BankAccountConfig/service.ts
@@ -14,6 +14,7 @@ type BankAccountConfigEntity = {
   name: string;
   description: string | null;
   percentage: number | null;
+  branch_id: number | null;
 };
 
 export class BankAccountConfigurationService {
@@ -44,12 +45,14 @@ export class BankAccountConfigurationService {
     name: string;
     description: string | null;
     percentage: number | null;
+    branch_id: number | null;
   }): BankAccountConfigEntity {
     return {
       id: config.id,
       name: config.name,
       description: config.description,
       percentage: config.percentage,
+      branch_id: config.branch_id,
     };
   }
 
@@ -79,6 +82,7 @@ export class BankAccountConfigurationService {
         name: true,
         description: true,
         percentage: true,
+        branch_id: true,
       },
     });
 
@@ -103,6 +107,7 @@ export class BankAccountConfigurationService {
           name: true,
           description: true,
           percentage: true,
+          branch_id: true,
         },
       }),
     ]);
@@ -159,6 +164,7 @@ export class BankAccountConfigurationService {
         name: true,
         description: true,
         percentage: true,
+        branch_id: true,
       },
     });
 

--- a/src/modules/finance/PaymentConfig/service.ts
+++ b/src/modules/finance/PaymentConfig/service.ts
@@ -9,6 +9,7 @@ type PaymentConfigEntity = {
   id: string;
   name: string;
   description: string | null;
+  branch_id: number | null;
 };
 
 export class PaymentConfigurationService {
@@ -16,11 +17,13 @@ export class PaymentConfigurationService {
     id: string;
     name: string;
     description: string | null;
+    branch_id: number | null;
   }): PaymentConfigEntity {
     return {
       id: config.id,
       name: config.name,
       description: config.description,
+      branch_id: config.branch_id,
     };
   }
 
@@ -44,6 +47,7 @@ export class PaymentConfigurationService {
         id: true,
         name: true,
         description: true,
+        branch_id: true,
       },
     });
 
@@ -67,6 +71,7 @@ export class PaymentConfigurationService {
           id: true,
           name: true,
           description: true,
+          branch_id: true,
         },
       }),
     ]);
@@ -114,6 +119,7 @@ export class PaymentConfigurationService {
         id: true,
         name: true,
         description: true,
+        branch_id: true,
       },
     });
 

--- a/src/modules/finance/ReceiptConfig/service.ts
+++ b/src/modules/finance/ReceiptConfig/service.ts
@@ -9,6 +9,7 @@ type ReceiptConfigEntity = {
   id: string;
   name: string;
   description: string | null;
+  branch_id: number | null;
 };
 
 export class ReceiptConfigurationService {
@@ -16,11 +17,13 @@ export class ReceiptConfigurationService {
     id: string;
     name: string;
     description: string | null;
+    branch_id: number | null;
   }): ReceiptConfigEntity {
     return {
       id: config.id,
       name: config.name,
       description: config.description,
+      branch_id: config.branch_id,
     };
   }
 
@@ -44,6 +47,7 @@ export class ReceiptConfigurationService {
         id: true,
         name: true,
         description: true,
+        branch_id: true,
       },
     });
 
@@ -67,6 +71,7 @@ export class ReceiptConfigurationService {
           id: true,
           name: true,
           description: true,
+          branch_id: true,
         },
       }),
     ]);
@@ -114,6 +119,7 @@ export class ReceiptConfigurationService {
         id: true,
         name: true,
         description: true,
+        branch_id: true,
       },
     });
 

--- a/src/modules/finance/TitheBreakdownConfig/service.ts
+++ b/src/modules/finance/TitheBreakdownConfig/service.ts
@@ -14,6 +14,7 @@ type TitheBreakdownConfigEntity = {
   name: string;
   description: string | null;
   percentage: number | null;
+  branch_id: number | null;
 };
 
 export class TitheBreakdownConfigurationService {
@@ -44,12 +45,14 @@ export class TitheBreakdownConfigurationService {
     name: string;
     description: string | null;
     percentage: number | null;
+    branch_id: number | null;
   }): TitheBreakdownConfigEntity {
     return {
       id: config.id,
       name: config.name,
       description: config.description,
       percentage: config.percentage,
+      branch_id: config.branch_id,
     };
   }
 
@@ -82,6 +85,7 @@ export class TitheBreakdownConfigurationService {
         name: true,
         description: true,
         percentage: true,
+        branch_id: true,
       },
     });
 
@@ -106,6 +110,7 @@ export class TitheBreakdownConfigurationService {
           name: true,
           description: true,
           percentage: true,
+          branch_id: true,
         },
       }),
     ]);
@@ -165,6 +170,7 @@ export class TitheBreakdownConfigurationService {
         name: true,
         description: true,
         percentage: true,
+        branch_id: true,
       },
     });
 


### PR DESCRIPTION
Adds branch_id field to BankAccountConfig, PaymentConfig, ReceiptConfig, and TitheBreakdownConfig services. Includes updates to entity types, mapper methods, and Prisma query selects to support branch-scoped configurations.