### PR TITLE
Add notification device tokens and sermon models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "cors": "^2.8.5",
         "date-fns": "^3.6.0",
         "docx": "^9.6.1",
+        "expo-server-sdk": "^6.1.0",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
         "http-status-codes": "^2.3.0",
@@ -4323,6 +4324,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4477,6 +4484,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expo-server-sdk": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-6.1.0.tgz",
+      "integrity": "sha512-ISuax1AQ7cpM5RAqcu8gVcoLL0ZKskJ5OLoMWmdITBe9nYjTucjdGyBq817YkIvTcj1pAUwx+9toUT7l/V7thA==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1",
+        "undici": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/express": {
@@ -6886,6 +6907,25 @@
         "node": "^16 || ^18 || >=20"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -7403,6 +7443,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rfdc": {
@@ -8488,7 +8537,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cors": "^2.8.5",
     "date-fns": "^3.6.0",
     "docx": "^9.6.1",
+    "expo-server-sdk": "^6.1.0",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
     "http-status-codes": "^2.3.0",

--- a/prisma/migrations/20260726130000_add_notification_device_tokens/migration.sql
+++ b/prisma/migrations/20260726130000_add_notification_device_tokens/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE `notification_device_tokens` (
+    `id` VARCHAR(191) NOT NULL,
+    `user_id` INTEGER NOT NULL,
+    `token` VARCHAR(512) NOT NULL,
+    `platform` VARCHAR(32) NOT NULL,
+    `device_id` VARCHAR(191) NULL,
+    `is_active` BOOLEAN NOT NULL DEFAULT true,
+    `last_seen_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `last_error_code` VARCHAR(64) NULL,
+    `last_error_message` VARCHAR(1024) NULL,
+    `last_error_at` DATETIME(3) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `notification_device_tokens_token_key`(`token`),
+    INDEX `notification_device_tokens_user_active_idx`(`user_id`, `is_active`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `notification_device_tokens` ADD CONSTRAINT `notification_device_tokens_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260726130000_add_sermons/migration.sql
+++ b/prisma/migrations/20260726130000_add_sermons/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE `sermon_series` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(191) NOT NULL,
+    `description` TEXT NULL,
+    `status` ENUM('DRAFT', 'PUBLISHED') NOT NULL DEFAULT 'DRAFT',
+    `branch_id` INTEGER NULL,
+    `created_by` INTEGER NOT NULL,
+    `published_at` DATETIME(3) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    INDEX `sermon_series_branch_id_idx`(`branch_id`),
+    INDEX `sermon_series_created_by_idx`(`created_by`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `sermon` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `series_id` INTEGER NOT NULL,
+    `youtube_url` VARCHAR(191) NOT NULL,
+    `title` VARCHAR(191) NOT NULL,
+    `video_id` VARCHAR(191) NULL,
+    `position` INTEGER NOT NULL DEFAULT 0,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `sermon_series_id_idx`(`series_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `sermon_series` ADD CONSTRAINT `sermon_series_branch_id_fkey` FOREIGN KEY (`branch_id`) REFERENCES `branch`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `sermon_series` ADD CONSTRAINT `sermon_series_created_by_fkey` FOREIGN KEY (`created_by`) REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `sermon` ADD CONSTRAINT `sermon_series_id_fkey` FOREIGN KEY (`series_id`) REFERENCES `sermon_series`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model user {
   acted_notifications      in_app_notification[]       @relation("notification_actor")
   notification_preferences notification_preference[]
   push_subscriptions       notification_push_subscription[]
+  device_tokens            notification_device_token[]
   push_delivery_jobs       notification_push_delivery_job[] @relation("notification_push_delivery_user")
   sms_delivery_jobs        notification_sms_delivery_job[]  @relation("notification_sms_delivery_user")
   system_failure_notification_settings system_notification_settings[] @relation("system_failure_notification_recipient")
@@ -2257,4 +2258,23 @@ model announcement {
   @@index([department_id])
   @@index([position_id])
   @@index([created_by])
+}
+
+model notification_device_token {
+  id                 String    @id @default(uuid())
+  user_id            Int
+  token              String    @unique @db.VarChar(512)
+  platform           String    @db.VarChar(32)
+  device_id          String?   @db.VarChar(191)
+  is_active          Boolean   @default(true)
+  last_seen_at       DateTime  @default(now())
+  last_error_code    String?   @db.VarChar(64)
+  last_error_message String?   @db.VarChar(1024)
+  last_error_at      DateTime?
+  created_at         DateTime  @default(now())
+  updated_at         DateTime  @default(now()) @updatedAt
+  user               user      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@index([user_id, is_active], map: "notification_device_tokens_user_active_idx")
+  @@map("notification_device_tokens")
 }


### PR DESCRIPTION
Add push notification infrastructure and sermon management features:

- Install expo-server-sdk (^6.1.0) for Expo push notification support
- Create notification_device_token model to track user device tokens with platform, device_id, error tracking, and active status
- Create sermon_series and sermon models for managing sermon content with series grouping and YouTube integration
- Add appropriate indexes on device tokens (user_id, is_active) and foreign key constraints with cascade deletes