### PR TITLE
Make pledge settlement optional, use shared Prisma client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ Node version: **18.18.0** (`.nvmrc` / `.node-version`).
 
 Requires `.env` with `DATABASE_URL`, `SHADOW_DATABASE_URL` (MySQL), `JWT_SECRET`, `PORT`. Optional: `RUN_BACKGROUND_JOBS=false` disables cron registration (see below), `PRISMA_TX_MAX_WAIT_MS`, `PRISMA_TX_TIMEOUT_MS`.
 
+Paystack (giving **and** pledge redemptions) reads `PAYSTACK_SECRET_KEY`, optionally `PAYSTACK_BASE_URL`, the shared donor-borne fee schedule `PAYSTACK_FEE_PERCENT` / `PAYSTACK_FEE_CAP_MINOR_UNITS` / `PAYSTACK_FEE_FLAT_MINOR_UNITS`, and two optional post-payment landing pages: `PAYSTACK_GIVING_CALLBACK_URL` and `PAYSTACK_PLEDGE_CALLBACK_URL`. Both fall back to `Frontend_URL` (`/out/giving-complete`, `/out/pledge-complete`). Callback URLs are always resolved server-side from a fixed set — clients send `client: "web" | "mobile"`, never a URL, because accepting one would be an open redirect on a payment flow. Full shapes: `Frontend/docs/GIVING_OPTIONS_BACKEND_CONTRACT.md` and `Frontend/docs/PLEDGE_PAYMENTS_BACKEND_CONTRACT.md`.
+
 No test runner, linter, or formatter is configured — do not fabricate `npm test`/`npm run lint` invocations.
 
 ## Architecture

--- a/src/modules/pledges/common.ts
+++ b/src/modules/pledges/common.ts
@@ -64,14 +64,17 @@ const nonEmpty = (value: unknown): value is string =>
 /**
  * The settlement account a pledge's online redemptions are routed to.
  *
- * Required on create - a pledge without one cannot be paid online, which is the
- * whole point of giving it a subaccount. On update it is optional, because a
- * meta-only edit (title, deadline, callers) must not force the caller to resend
- * bank details, and because pledges predating this feature have none.
+ * Optional everywhere, so a client that never sends it can still create and
+ * edit pledges - they just cannot be redeemed online, exactly like every pledge
+ * that predates this feature. Supplying one later mints the subaccount.
+ *
+ * "Optional" means absent ENTIRELY. A payload carrying some of the fields is a
+ * client bug, not an opt-out, so it is validated in full and rejected: silently
+ * dropping a half-filled account would leave the pledge quietly unpayable while
+ * the dashboard showed the details as saved.
  */
 export const validateSettlementAccount = (
   body: any,
-  opts: { required: boolean },
 ): PledgeSettlementAccount | undefined => {
   const provided =
     nonEmpty(body?.settlement_bank) ||
@@ -79,15 +82,7 @@ export const validateSettlementAccount = (
     nonEmpty(body?.account_name) ||
     nonEmpty(body?.bank_name);
 
-  if (!provided) {
-    if (opts.required) {
-      throw new PledgeHttpError(
-        400,
-        "Settlement account details are required so payments to this pledge can be routed",
-      );
-    }
-    return undefined;
-  }
+  if (!provided) return undefined;
 
   const accountType = nonEmpty(body?.account_type)
     ? body.account_type.trim()

--- a/src/modules/pledges/pledges/controller.ts
+++ b/src/modules/pledges/pledges/controller.ts
@@ -11,9 +11,21 @@ const service = new PledgeService();
 export const createPledge = async (req: Request, res: Response) => {
   try {
     const payload = validatePledgeMutationPayload(req.body);
-    // Required on create: a pledge exists to be redeemed, and it cannot take an
-    // online redemption without a subaccount to route it to.
-    const account = validateSettlementAccount(req.body, { required: true });
+    /**
+     * Optional, deliberately.
+     *
+     * Every pledge created through the dashboard supplies these - the form
+     * requires them - and gets a Paystack subaccount so members can redeem it
+     * online. But rejecting a create that omits them would break any client
+     * still running a build from before this field existed, for a pledge that
+     * is otherwise perfectly valid. A pledge without an account is simply not
+     * payable online (`can_be_paid_online: false`), exactly like every pledge
+     * that predates this feature, and saving one later mints the subaccount.
+     *
+     * Partial details are still rejected: `validateSettlementAccount` only
+     * returns undefined when the account is absent entirely.
+     */
+    const account = validateSettlementAccount(req.body);
     const data = await service.create(payload, (req as any).user?.id, account);
     return res.status(201).json({ message: "Pledge created", data });
   } catch (e) {
@@ -46,8 +58,8 @@ export const getPledge = async (req: Request, res: Response) => {
 export const updatePledge = async (req: Request, res: Response) => {
   try {
     const payload = validatePledgeMutationPayload(req.body, { requireGroups: false });
-    // Optional on update: a meta-only edit must not have to resend bank details.
-    const account = validateSettlementAccount(req.body, { required: false });
+    // A meta-only edit omits these entirely and leaves the account untouched.
+    const account = validateSettlementAccount(req.body);
     const id = Number(req.body?.id ?? req.query?.id);
     const data = await service.update(id, payload, account);
     return res.status(200).json({ message: "Pledge updated", data });

--- a/src/modules/pledges/pledges/service.ts
+++ b/src/modules/pledges/pledges/service.ts
@@ -1,4 +1,5 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../../Models/context";
 import {
   createSubaccount,
   updateSubaccount,
@@ -8,8 +9,6 @@ import {
   resolveBranchIdOrDefault,
 } from "../../branches/branchService";
 import { PledgeHttpError, type PledgeSettlementAccount } from "../common";
-
-const prisma = new PrismaClient();
 
 const num = (d: Prisma.Decimal | null | undefined) => (d ? Number(d) : 0);
 

--- a/src/modules/pledges/redemptions/service.ts
+++ b/src/modules/pledges/redemptions/service.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, Prisma } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../../Models/context";
 
 export class RedemptionService {
   async create(body: any, actorId?: number) {


### PR DESCRIPTION
Changes settlement account validation from required-on-create to optional everywhere, allowing older clients to still create pledges without bank details. Pledges without accounts simply cannot be redeemed online until details are supplied later.

Also fixes pledges services to use the shared Prisma client from src/Models/context instead of instantiating new clients, per architecture guidelines.

Updates CLAUDE.md with Paystack configuration details and callback URL contract locations.