### PR TITLE
Add retry/delete for contributions and pledge payments

### DIFF
--- a/src/modules/finance/GivingOption/contributionController.ts
+++ b/src/modules/finance/GivingOption/contributionController.ts
@@ -8,7 +8,9 @@ import { GivingContributionService } from "./contributionService";
 import {
   parseContributionFilters,
   parsePreviewAmount,
+  parseReferenceQuery,
   validateInitializePayload,
+  validateRetryPayload,
 } from "./contributionValidation";
 
 const service = new GivingContributionService();
@@ -66,6 +68,31 @@ export class GivingContributionController {
         message: "Payment started",
         data: result,
       });
+    } catch (error) {
+      return sendFinanceError(res, error);
+    }
+  }
+
+  async retry(req: Request, res: Response): Promise<Response> {
+    try {
+      const payload = validateRetryPayload(req.body);
+      const result = await service.retry(getActorUserId(req), payload);
+
+      return res.status(201).json({
+        message: "Payment started",
+        data: result,
+      });
+    } catch (error) {
+      return sendFinanceError(res, error);
+    }
+  }
+
+  async remove(req: Request, res: Response): Promise<Response> {
+    try {
+      const reference = parseReferenceQuery(req.query?.reference);
+      const data = await service.deleteOwn(getActorUserId(req), reference);
+
+      return res.status(200).json({ message: "Contribution removed", data });
     } catch (error) {
       return sendFinanceError(res, error);
     }

--- a/src/modules/finance/GivingOption/contributionService.ts
+++ b/src/modules/finance/GivingOption/contributionService.ts
@@ -14,6 +14,7 @@ import { FinanceHttpError, PaginationQuery } from "../common";
 import type {
   ContributionListFilters,
   InitializeContributionPayload,
+  RetryContributionPayload,
 } from "./contributionValidation";
 
 /**
@@ -74,6 +75,18 @@ const clampPagination = (
  * second one, so anything non-terminal is left for the webhook to resolve.
  */
 const TERMINAL_FAILURE_STATUSES = new Set(["failed", "abandoned", "reversed"]);
+
+/**
+ * The statuses a donor may retry or delete their own attempt from: the charge
+ * is resolved and no money reached the fund, so there is nothing to unwind.
+ *
+ * "pending" is deliberately absent. A mobile money charge sits pending while
+ * the customer completes a USSD prompt, so deleting one would drop the row a
+ * later webhook needs - the money would be collected against a reference the
+ * app no longer recognises. Pending rows are verified against Paystack first
+ * (see resolveStatus) and only act on whatever that settles them to.
+ */
+const DONOR_ACTIONABLE_STATUSES = new Set(["failed", "abandoned"]);
 
 const buildReference = (): string =>
   `WWM-GIVE-${randomUUID().replace(/-/g, "").slice(0, 20).toUpperCase()}`;
@@ -190,6 +203,14 @@ export const resolveCallbackUrl = (
  */
 const branchVisibilityFilter = (branchId: number | null) =>
   branchId ? [{ branch_id: branchId }, { branch_id: null }] : [{ branch_id: null }];
+
+/** The donor fields every payment start needs, already checked for an email. */
+type Donor = {
+  id: number;
+  name: string;
+  email: string;
+  branch_id: number | null;
+};
 
 type ContributionRow = {
   id: string;
@@ -513,10 +534,11 @@ export class GivingContributionService {
     });
   }
 
-  async initialize(
-    userId: number | undefined,
-    payload: InitializeContributionPayload,
-  ) {
+  /**
+   * The donor, with the email a receipt needs already guaranteed. Shared by
+   * every member-facing entry point so the 401/404/422 wording cannot drift.
+   */
+  private async loadDonor(userId: number | undefined): Promise<Donor> {
     if (!userId) {
       throw new FinanceHttpError(401, "Not authorized");
     }
@@ -537,11 +559,191 @@ export class GivingContributionService {
       );
     }
 
+    return {
+      id: donor.id,
+      name: donor.name,
+      email: donor.email,
+      branch_id: donor.branch_id,
+    };
+  }
+
+  async initialize(
+    userId: number | undefined,
+    payload: InitializeContributionPayload,
+  ) {
+    const donor = await this.loadDonor(userId);
+
+    return this.startContribution(
+      donor,
+      payload.giving_option_id,
+      payload.amount,
+      payload.client,
+    );
+  }
+
+  /**
+   * A fresh attempt at an existing one, for a donor whose payment did not go
+   * through. A NEW reference is minted rather than reusing the old one:
+   * Paystack requires references to be unique per initialization, and keeping
+   * each attempt as its own row is what lets the failed one still be produced
+   * in a dispute. The amount and the fund are read off the original row, so a
+   * retry cannot become a different gift.
+   */
+  async retry(userId: number | undefined, payload: RetryContributionPayload) {
+    const donor = await this.loadDonor(userId);
+    const existing = await this.loadOwnContribution(donor.id, payload.reference);
+    const status = await this.resolveStatus(existing);
+
+    if (status === "success") {
+      throw new FinanceHttpError(
+        409,
+        "This payment already went through. Check your giving history.",
+      );
+    }
+
+    if (!DONOR_ACTIONABLE_STATUSES.has(status)) {
+      throw new FinanceHttpError(
+        409,
+        "This payment is still being processed. Please wait a moment before trying again.",
+      );
+    }
+
+    return this.startContribution(
+      donor,
+      existing.giving_option_id,
+      existing.amount,
+      payload.client,
+    );
+  }
+
+  /**
+   * Removes a donor's own attempt that never collected money.
+   *
+   * A hard delete, not a soft one: the row records an attempt, not a receipt,
+   * and nothing downstream (reporting, reconciliation, the receipt sweep)
+   * counts a non-success row. A successful payment can never be deleted here,
+   * and a pending one is verified against Paystack first - so the only rows
+   * that can go are ones Paystack itself has already called dead.
+   */
+  async deleteOwn(userId: number | undefined, reference: string) {
+    const donor = await this.loadDonor(userId);
+    const existing = await this.loadOwnContribution(donor.id, reference);
+    const status = await this.resolveStatus(existing);
+
+    if (status === "success") {
+      throw new FinanceHttpError(
+        409,
+        "A completed payment cannot be deleted. Contact the church office if this is wrong.",
+      );
+    }
+
+    if (!DONOR_ACTIONABLE_STATUSES.has(status)) {
+      throw new FinanceHttpError(
+        409,
+        "This payment is still being processed and cannot be removed yet. Please try again shortly.",
+      );
+    }
+
+    // Conditional, not a plain delete by id: a webhook could settle this row
+    // between resolveStatus reading it and this statement running, and deleting
+    // a settled payment would erase a collected gift. count 0 means exactly
+    // that happened, so the donor is told rather than silently succeeding.
+    const removed = await prisma.givingContribution.deleteMany({
+      where: { reference, user_id: donor.id, status: { not: "success" } },
+    });
+
+    if (removed.count === 0) {
+      throw new FinanceHttpError(
+        409,
+        "This payment completed while you were removing it. Check your giving history.",
+      );
+    }
+
+    return { reference };
+  }
+
+  /** The caller's own attempt, or a 404 that does not reveal whose it is. */
+  private async loadOwnContribution(userId: number, reference: string) {
+    const existing = await prisma.givingContribution.findUnique({
+      where: { reference },
+      select: {
+        id: true,
+        reference: true,
+        user_id: true,
+        branch_id: true,
+        status: true,
+        amount: true,
+        giving_option_id: true,
+      },
+    });
+
+    // Same 404 for "no such reference" and "not yours", so this cannot be used
+    // to probe which references exist.
+    if (!existing || existing.user_id !== userId) {
+      throw new FinanceHttpError(404, "Contribution not found");
+    }
+
+    return existing;
+  }
+
+  /**
+   * The status to act on, having given Paystack the last word on a pending row.
+   *
+   * A pending row is the dangerous case: it may be a live mobile money charge,
+   * or it may be a checkout the donor closed half an hour ago. Asking Paystack
+   * settles it through the same idempotent path as the webhook. If that call
+   * fails, "pending" is returned unchanged - which makes the caller refuse the
+   * action, the safe direction when we cannot tell whether money moved.
+   */
+  private async resolveStatus(existing: {
+    reference: string;
+    branch_id: number | null;
+    status: string;
+  }): Promise<string> {
+    if (existing.status !== "pending") {
+      return existing.status;
+    }
+
+    try {
+      const transaction = await verifyTransaction(
+        existing.reference,
+        existing.branch_id,
+      );
+      await settleContribution(transaction);
+    } catch (error) {
+      logger.warn(
+        `[giving] could not verify ${existing.reference} before a donor action: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { reference: existing.reference },
+      );
+      return "pending";
+    }
+
+    const settled = await prisma.givingContribution.findUnique({
+      where: { reference: existing.reference },
+      select: { status: true },
+    });
+
+    return settled?.status ?? "pending";
+  }
+
+  /**
+   * Creates the attempt row and hands it to Paystack. Shared by initialize and
+   * retry so the fee gross-up, the callback URL, the failure bookkeeping and
+   * the drift marking cannot drift apart between the two entry points.
+   */
+  private async startContribution(
+    donor: Donor,
+    givingOptionId: string,
+    amount: number,
+    client: PaymentClient,
+  ) {
     // Re-check visibility here rather than trusting that the client only ever
     // shows what /available returned.
     const option = await prisma.givingOption.findFirst({
       where: {
-        id: payload.giving_option_id,
+        id: givingOptionId,
         archived_at: null,
         is_active: true,
         paystack_synced_at: { not: null },
@@ -556,9 +758,9 @@ export class GivingContributionService {
     const reference = buildReference();
 
     // The donor covers the Paystack fee, so the subaccount receives the whole
-    // donation. `payload.amount` is the donation; the card is charged the sum.
-    const fee = computeDonorBorneFee(payload.amount);
-    const amountCharged = payload.amount + fee;
+    // donation. `amount` is the donation; the card is charged the sum.
+    const fee = computeDonorBorneFee(amount);
+    const amountCharged = amount + fee;
 
     const contribution = await prisma.givingContribution.create({
       data: {
@@ -569,7 +771,7 @@ export class GivingContributionService {
         user_id: donor.id,
         donor_name: donor.name,
         donor_email: donor.email,
-        amount: payload.amount,
+        amount,
         fee,
         amount_charged: amountCharged,
         currency: option.currency,
@@ -579,7 +781,7 @@ export class GivingContributionService {
       select: CONTRIBUTION_SELECT,
     });
 
-    const callbackUrl = resolveCallbackUrl(payload.client);
+    const callbackUrl = resolveCallbackUrl(client);
 
     try {
       const result = await initializeTransaction(
@@ -602,7 +804,7 @@ export class GivingContributionService {
             giving_option_id: option.id,
             giving_option_name: option.name,
             user_id: donor.id,
-            donation_minor_units: payload.amount,
+            donation_minor_units: amount,
             fee_minor_units: fee,
           },
         },

--- a/src/modules/finance/GivingOption/contributionValidation.ts
+++ b/src/modules/finance/GivingOption/contributionValidation.ts
@@ -90,6 +90,53 @@ export const validateInitializePayload = (
   };
 };
 
+/**
+ * A retry names an existing attempt by its reference and nothing else. The
+ * amount and the giving option are read off that row server-side rather than
+ * resent, so a client cannot use "retry" to give a different amount to a
+ * different fund than the row it claims to be retrying.
+ */
+export type RetryContributionPayload = {
+  reference: string;
+  client: PaymentClient;
+};
+
+export const validateRetryPayload = (
+  body: unknown,
+): RetryContributionPayload => {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new FinanceHttpError(422, "Invalid request payload");
+  }
+
+  const payload = body as { reference?: unknown; client?: unknown };
+
+  if (
+    typeof payload.reference !== "string" ||
+    payload.reference.trim().length === 0
+  ) {
+    throw new FinanceHttpError(422, "reference is required");
+  }
+
+  return {
+    reference: payload.reference.trim(),
+    client: parsePaymentClient(payload.client),
+  };
+};
+
+/**
+ * A reference taken from the query string, for DELETE - which has no body worth
+ * relying on across HTTP clients. Rejects arrays: Express parses
+ * `?reference[]=a&reference[]=b` into one, and `String(["a"])` would silently
+ * accept it.
+ */
+export const parseReferenceQuery = (raw: unknown): string => {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new FinanceHttpError(422, "reference is required");
+  }
+
+  return raw.trim();
+};
+
 export const CONTRIBUTION_STATUSES = [
   "pending",
   "success",

--- a/src/modules/finance/GivingOption/route.ts
+++ b/src/modules/finance/GivingOption/route.ts
@@ -401,6 +401,82 @@ givingOptionRouter.get(
 
 /**
  * @swagger
+ * /givingoption/my-contributions:
+ *   delete:
+ *     summary: Remove one of the caller's own unsuccessful attempts
+ *     description: >
+ *       Only the caller's own row, and only one that never collected money. A
+ *       pending row is verified against Paystack first and refused (409) if it
+ *       is still live or turns out to have succeeded, so a mobile money charge
+ *       part-way through a USSD prompt can never be deleted out from under the
+ *       webhook that will settle it.
+ *     tags: [Giving Options]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: reference
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Removed
+ *       404:
+ *         description: Unknown reference, or it belongs to another member
+ *       409:
+ *         description: The payment succeeded, or is still being processed
+ */
+givingOptionRouter.delete(
+  "/my-contributions",
+  [protect],
+  contributionController.remove,
+);
+
+/**
+ * @swagger
+ * /givingoption/retry-payment:
+ *   post:
+ *     summary: Start a fresh attempt at one of the caller's failed payments
+ *     description: >
+ *       Reads the fund and the amount off the original row - a retry cannot
+ *       become a different gift - and mints a NEW reference, because Paystack
+ *       requires references to be unique per initialization. The failed attempt
+ *       is left in place so it can still be produced in a dispute.
+ *     tags: [Giving Options]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [reference]
+ *             properties:
+ *               reference:
+ *                 type: string
+ *                 description: The reference of the attempt being retried
+ *               client:
+ *                 type: string
+ *                 enum: [web, mobile]
+ *                 default: mobile
+ *     responses:
+ *       201:
+ *         description: Returns checkoutUrl and the new reference
+ *       404:
+ *         description: Unknown reference, or the giving option is no longer available
+ *       409:
+ *         description: The payment succeeded, or is still being processed
+ */
+givingOptionRouter.post(
+  "/retry-payment",
+  [protect],
+  contributionController.retry,
+);
+
+/**
+ * @swagger
  * /givingoption/contributions:
  *   get:
  *     summary: All contributions, for finance staff

--- a/src/modules/pledges/payments/controller.ts
+++ b/src/modules/pledges/payments/controller.ts
@@ -3,7 +3,9 @@ import { PledgeHttpError, sendPledgeError } from "../common";
 import { PledgePaymentService } from "./service";
 import {
   parsePreviewAmount,
+  parseReferenceQuery,
   validateInitializePledgePayment,
+  validateRetryPledgePayment,
 } from "./validation";
 
 const service = new PledgePaymentService();
@@ -70,6 +72,26 @@ export const initializePledgePayment = async (req: Request, res: Response) => {
     const payload = validateInitializePledgePayment(req.body);
     const data = await service.initialize(getActorUserId(req), payload);
     return res.status(201).json({ message: "Payment started", data });
+  } catch (error) {
+    return sendPledgeError(res, error);
+  }
+};
+
+export const retryPledgePayment = async (req: Request, res: Response) => {
+  try {
+    const payload = validateRetryPledgePayment(req.body);
+    const data = await service.retry(getActorUserId(req), payload);
+    return res.status(201).json({ message: "Payment started", data });
+  } catch (error) {
+    return sendPledgeError(res, error);
+  }
+};
+
+export const deleteMyPledgePayment = async (req: Request, res: Response) => {
+  try {
+    const reference = parseReferenceQuery(req.query?.reference);
+    const data = await service.deleteOwn(getActorUserId(req), reference);
+    return res.status(200).json({ message: "Payment removed", data });
   } catch (error) {
     return sendPledgeError(res, error);
   }

--- a/src/modules/pledges/payments/route.ts
+++ b/src/modules/pledges/payments/route.ts
@@ -1,11 +1,13 @@
 import { Router } from "express";
 import { Permissions } from "../../../middleWare/authorization";
 import {
+  deleteMyPledgePayment,
   initializePledgePayment,
   listMyPledgePayments,
   listMyPledges,
   listPledgePayments,
   previewPledgeFee,
+  retryPledgePayment,
   verifyPledgePayment,
 } from "./controller";
 
@@ -133,6 +135,80 @@ pledgePaymentsRouter.post("/initialize-payment", [protect], initializePledgePaym
  *         description: Paginated payments
  */
 pledgePaymentsRouter.get("/my-pledge-payments", [protect], listMyPledgePayments);
+
+/**
+ * @swagger
+ * /pledges/my-pledge-payments:
+ *   delete:
+ *     summary: Remove one of the caller's own unsuccessful payments
+ *     description: >
+ *       Only the caller's own row, and only one that never collected money. A
+ *       pending row is verified against Paystack first and refused (409) if it
+ *       is still live or turns out to have succeeded, so a mobile money charge
+ *       part-way through a USSD prompt can never be deleted out from under the
+ *       webhook that will settle it and write its redemption.
+ *     tags: [Pledge Payments]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: reference
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Removed
+ *       404:
+ *         description: Unknown reference, or it belongs to another member
+ *       409:
+ *         description: The payment succeeded, or is still being processed
+ */
+pledgePaymentsRouter.delete(
+  "/my-pledge-payments",
+  [protect],
+  deleteMyPledgePayment,
+);
+
+/**
+ * @swagger
+ * /pledges/retry-payment:
+ *   post:
+ *     summary: Start a fresh attempt at one of the caller's failed payments
+ *     description: >
+ *       Reads the pledge and the amount off the original row - a retry cannot
+ *       become a payment against a different pledge - and mints a NEW reference,
+ *       because Paystack requires references to be unique per initialization.
+ *       The outstanding balance is re-checked, so a retry of an amount redeemed
+ *       another way in the meantime is refused rather than overpaying.
+ *     tags: [Pledge Payments]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [reference]
+ *             properties:
+ *               reference:
+ *                 type: string
+ *               client:
+ *                 type: string
+ *                 enum: [web, mobile]
+ *                 default: mobile
+ *     responses:
+ *       201:
+ *         description: Returns checkoutUrl and the new reference
+ *       404:
+ *         description: Unknown reference, or the pledge is no longer payable
+ *       409:
+ *         description: The payment succeeded, is still processing, or the pledge changed
+ *       422:
+ *         description: The amount now exceeds the outstanding balance
+ */
+pledgePaymentsRouter.post("/retry-payment", [protect], retryPledgePayment);
 
 /**
  * @swagger

--- a/src/modules/pledges/payments/service.ts
+++ b/src/modules/pledges/payments/service.ts
@@ -15,6 +15,7 @@ import { PledgeHttpError } from "../common";
 import type {
   InitializePledgePaymentPayload,
   PaymentClient,
+  RetryPledgePaymentPayload,
 } from "./validation";
 
 /**
@@ -58,6 +59,18 @@ const MAX_LIST_PAGE_SIZE = 200;
  * left for the webhook to resolve.
  */
 const TERMINAL_FAILURE_STATUSES = new Set(["failed", "abandoned", "reversed"]);
+
+/**
+ * The statuses a payer may retry or delete their own attempt from: the charge
+ * is resolved, no redemption was written, and there is nothing to unwind.
+ *
+ * "pending" is deliberately absent - a mobile money charge sits pending while
+ * the customer completes a USSD prompt, so deleting one would drop the row a
+ * later webhook needs and the money would land against a reference the app no
+ * longer recognises. Pending rows are verified against Paystack first (see
+ * resolveStatus) and only whatever that settles them to is acted on.
+ */
+const PAYER_ACTIONABLE_STATUSES = new Set(["failed", "abandoned"]);
 
 /** Marks a redemption as having come from the online payment path. */
 export const ONLINE_REDEMPTION_METHOD = "paystack";
@@ -128,6 +141,13 @@ const resolveCallbackUrl = (client: PaymentClient): string | undefined => {
   return `${frontendUrl.replace(/\/+$/, "")}${
     client === "web" ? PLEDGE_WEB_CALLBACK_PATH : PLEDGE_CALLBACK_PATH
   }`;
+};
+
+/** The payer fields every payment start needs, already checked for an email. */
+type Payer = {
+  id: number;
+  name: string;
+  email: string;
 };
 
 type ReceiptRow = {
@@ -508,10 +528,11 @@ export class PledgePaymentService {
     });
   }
 
-  async initialize(
-    userId: number | undefined,
-    payload: InitializePledgePaymentPayload,
-  ) {
+  /**
+   * The payer, with the email a receipt needs already guaranteed. Shared by
+   * every member-facing entry point so the 401/404/422 wording cannot drift.
+   */
+  private async loadPayer(userId: number | undefined): Promise<Payer> {
     if (!userId) throw new PledgeHttpError(401, "Not authorized");
 
     const payer = await prisma.user.findUnique({
@@ -528,8 +549,200 @@ export class PledgePaymentService {
       );
     }
 
+    return { id: payer.id, name: payer.name, email: payer.email };
+  }
+
+  async initialize(
+    userId: number | undefined,
+    payload: InitializePledgePaymentPayload,
+  ) {
+    const payer = await this.loadPayer(userId);
+
+    return this.startPayment(
+      payer,
+      payload.pledger_id,
+      payload.amount,
+      payload.client,
+    );
+  }
+
+  /**
+   * A fresh attempt at an existing one, for a payer whose payment did not go
+   * through. A NEW reference is minted rather than reusing the old one:
+   * Paystack requires references to be unique per initialization, and keeping
+   * each attempt as its own row is what lets the failed one still be produced
+   * in a dispute. The pledge and the amount are read off the original row, so a
+   * retry cannot become a payment against a different pledge.
+   *
+   * The outstanding balance is re-checked by startPayment, so a retry of an
+   * amount that has since been redeemed another way is refused with the real
+   * balance rather than overpaying the pledge.
+   */
+  async retry(userId: number | undefined, payload: RetryPledgePaymentPayload) {
+    const payer = await this.loadPayer(userId);
+    const existing = await this.loadOwnPayment(payer.id, payload.reference);
+    const status = await this.resolveStatus(existing);
+
+    if (status === "success") {
+      throw new PledgeHttpError(
+        409,
+        "This payment already went through. Check your payment history.",
+      );
+    }
+
+    if (!PAYER_ACTIONABLE_STATUSES.has(status)) {
+      throw new PledgeHttpError(
+        409,
+        "This payment is still being processed. Please wait a moment before trying again.",
+      );
+    }
+
+    // pledger_id is SetNull, so replacing a pledge's groups detaches old
+    // payments from the pledger they were made for. There is nothing left to
+    // credit a retry to, so it cannot be restarted from here.
+    if (!existing.pledger_id) {
+      throw new PledgeHttpError(
+        409,
+        "This pledge has changed since that attempt. Start the payment again from your pledges.",
+      );
+    }
+
+    return this.startPayment(
+      payer,
+      existing.pledger_id,
+      existing.amount,
+      payload.client,
+    );
+  }
+
+  /**
+   * Removes a payer's own attempt that never collected money.
+   *
+   * A hard delete, not a soft one: the row records an attempt, not a receipt,
+   * it produced no redemption, and nothing downstream counts a non-success row.
+   * A successful payment can never be deleted here, and a pending one is
+   * verified against Paystack first - so the only rows that can go are ones
+   * Paystack itself has already called dead.
+   */
+  async deleteOwn(userId: number | undefined, reference: string) {
+    const payer = await this.loadPayer(userId);
+    const existing = await this.loadOwnPayment(payer.id, reference);
+    const status = await this.resolveStatus(existing);
+
+    if (status === "success") {
+      throw new PledgeHttpError(
+        409,
+        "A completed payment cannot be deleted. Contact the church office if this is wrong.",
+      );
+    }
+
+    if (!PAYER_ACTIONABLE_STATUSES.has(status)) {
+      throw new PledgeHttpError(
+        409,
+        "This payment is still being processed and cannot be removed yet. Please try again shortly.",
+      );
+    }
+
+    // Conditional on both status AND redemption_id, not a plain delete by id: a
+    // webhook could settle this row between resolveStatus reading it and this
+    // statement running, and deleting a settled payment would erase a collected
+    // redemption. count 0 means exactly that happened.
+    const removed = await prisma.pledge_payment.deleteMany({
+      where: {
+        reference,
+        user_id: payer.id,
+        status: { not: "success" },
+        redemption_id: null,
+      },
+    });
+
+    if (removed.count === 0) {
+      throw new PledgeHttpError(
+        409,
+        "This payment completed while you were removing it. Check your payment history.",
+      );
+    }
+
+    return { reference };
+  }
+
+  /** The caller's own attempt, or a 404 that does not reveal whose it is. */
+  private async loadOwnPayment(userId: number, reference: string) {
+    const existing = await prisma.pledge_payment.findUnique({
+      where: { reference },
+      select: {
+        id: true,
+        reference: true,
+        user_id: true,
+        branch_id: true,
+        status: true,
+        amount: true,
+        pledger_id: true,
+      },
+    });
+
+    // Same 404 for "no such reference" and "not yours", so this cannot be used
+    // to probe which references exist.
+    if (!existing || existing.user_id !== userId) {
+      throw new PledgeHttpError(404, "Payment not found");
+    }
+
+    return existing;
+  }
+
+  /**
+   * The status to act on, having given Paystack the last word on a pending row.
+   *
+   * A pending row may be a live mobile money charge or a checkout the payer
+   * closed half an hour ago. Asking Paystack settles it through the same
+   * idempotent path as the webhook. If that call fails, "pending" is returned
+   * unchanged - which makes the caller refuse the action, the safe direction
+   * when we cannot tell whether money moved.
+   */
+  private async resolveStatus(existing: {
+    reference: string;
+    branch_id: number | null;
+    status: string;
+  }): Promise<string> {
+    if (existing.status !== "pending") return existing.status;
+
+    try {
+      const transaction = await verifyTransaction(
+        existing.reference,
+        existing.branch_id,
+      );
+      await settlePledgePayment(transaction);
+    } catch (error) {
+      logger.warn(
+        `[pledge] could not verify ${existing.reference} before a payer action: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { reference: existing.reference },
+      );
+      return "pending";
+    }
+
+    const settled = await prisma.pledge_payment.findUnique({
+      where: { reference: existing.reference },
+      select: { status: true },
+    });
+
+    return settled?.status ?? "pending";
+  }
+
+  /**
+   * Creates the attempt row and hands it to Paystack. Shared by initialize and
+   * retry so the balance cap, the fee gross-up, the callback URL and the drift
+   * marking cannot drift apart between the two entry points.
+   */
+  private async startPayment(
+    payer: Payer,
+    pledgerId: number,
+    amount: number,
+    client: PaymentClient,
+  ) {
     const pledger = await prisma.pledger.findUnique({
-      where: { id: payload.pledger_id },
+      where: { id: pledgerId },
       include: {
         redemptions: { select: { amount: true } },
         group: { include: { pledge: true } },
@@ -538,7 +751,7 @@ export class PledgePaymentService {
 
     // Same 404 for "no such pledger" and "not yours", so this cannot be used to
     // probe which pledger ids exist.
-    if (!pledger || pledger.user_id !== userId) {
+    if (!pledger || pledger.user_id !== payer.id) {
       throw new PledgeHttpError(404, "Pledge not found");
     }
 
@@ -566,7 +779,7 @@ export class PledgePaymentService {
     // Capping at the outstanding balance rather than accepting anything: an
     // overpayment on a pledge has no meaning in the ledger, and refunding one
     // is manual work for the finance team.
-    if (payload.amount > remainingMinorUnits) {
+    if (amount > remainingMinorUnits) {
       throw new PledgeHttpError(
         422,
         `The outstanding balance on this pledge is ${pledge.currency} ${(
@@ -578,10 +791,10 @@ export class PledgePaymentService {
     const reference = buildReference();
 
     // The payer covers the Paystack fee, so the pledge's subaccount receives
-    // the whole redemption. `payload.amount` is the redemption; the card is
-    // charged the sum.
-    const fee = computeDonorBorneFee(payload.amount);
-    const amountCharged = payload.amount + fee;
+    // the whole redemption. `amount` is the redemption; the card is charged the
+    // sum.
+    const fee = computeDonorBorneFee(amount);
+    const amountCharged = amount + fee;
 
     const payment = await prisma.pledge_payment.create({
       data: {
@@ -593,7 +806,7 @@ export class PledgePaymentService {
         payer_email: payer.email,
         subaccount_code: pledge.subaccount_code,
         user_id: payer.id,
-        amount: payload.amount,
+        amount,
         fee,
         amount_charged: amountCharged,
         currency: pledge.currency,
@@ -603,7 +816,7 @@ export class PledgePaymentService {
       select: PAYMENT_SELECT,
     });
 
-    const callbackUrl = resolveCallbackUrl(payload.client);
+    const callbackUrl = resolveCallbackUrl(client);
 
     try {
       const result = await initializeTransaction(
@@ -626,7 +839,7 @@ export class PledgePaymentService {
             pledger_id: pledger.id,
             pledge_title: pledge.title,
             user_id: payer.id,
-            redemption_minor_units: payload.amount,
+            redemption_minor_units: amount,
             fee_minor_units: fee,
           },
         },

--- a/src/modules/pledges/payments/validation.ts
+++ b/src/modules/pledges/payments/validation.ts
@@ -81,6 +81,52 @@ export const validateInitializePledgePayment = (
 };
 
 /**
+ * A retry names an existing attempt by its reference and nothing else. The
+ * amount and the pledge are read off that row server-side rather than resent,
+ * so "retry" cannot be used to pay a different amount against a different
+ * pledge than the row it claims to be retrying.
+ */
+export type RetryPledgePaymentPayload = {
+  reference: string;
+  client: PaymentClient;
+};
+
+export const validateRetryPledgePayment = (
+  body: unknown,
+): RetryPledgePaymentPayload => {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new PledgeHttpError(400, "Invalid request payload");
+  }
+
+  const payload = body as { reference?: unknown; client?: unknown };
+
+  if (
+    typeof payload.reference !== "string" ||
+    payload.reference.trim().length === 0
+  ) {
+    throw new PledgeHttpError(400, "reference is required");
+  }
+
+  return {
+    reference: payload.reference.trim(),
+    client: parsePaymentClient(payload.client),
+  };
+};
+
+/**
+ * A reference taken from the query string, for DELETE - which has no body worth
+ * relying on across HTTP clients. Rejects anything non-scalar: Express parses
+ * `?reference[]=a` into an array, and `String(["a"])` would silently accept it.
+ */
+export const parseReferenceQuery = (raw: unknown): string => {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new PledgeHttpError(400, "reference is required");
+  }
+
+  return raw.trim();
+};
+
+/**
  * The amount for a fee preview. Comes from a query string, so a numeric string
  * is the expected form here rather than a client bug.
  */


### PR DESCRIPTION
Add member-facing retry and delete flows for giving contributions and pledge payments. New endpoints and docs: POST /givingoption/retry-payment, DELETE /givingoption/my-contributions, POST /pledges/retry-payment, DELETE /pledges/my-pledge-payments. Introduces validation types/parse helpers, controller handlers, and service refactors (loadDonor/loadPayer, startContribution/startPayment, resolveStatus that verifies pending transactions with Paystack). Adds actionable-status sets and conditional deletes to avoid removing settled payments. Returns 201 for started retries and 200 for deletes; preserves 404/409 semantics for ownership and processing state.