### PR TITLE
Add read receipts, position categories, and stats

### DIFF
--- a/prisma/migrations/20260804120000_add_position_category/migration.sql
+++ b/prisma/migrations/20260804120000_add_position_category/migration.sql
@@ -1,0 +1,4 @@
+-- Add a booking-reason category label to positions (e.g. "Marriage & family",
+-- "Spiritual guidance", "Ministry & serving", "Something else") so staff can be
+-- filtered by reason when booking an appointment.
+ALTER TABLE `position` ADD COLUMN `category` VARCHAR(191) NULL;

--- a/prisma/migrations/20260804130000_add_announcement_read_receipts/migration.sql
+++ b/prisma/migrations/20260804130000_add_announcement_read_receipts/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE `announcement_read_receipt` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `announcement_id` INTEGER NOT NULL,
+    `user_id` INTEGER NOT NULL,
+    `read_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `announcement_read_receipt_announcement_user_key`(`announcement_id`, `user_id`),
+    INDEX `announcement_read_receipt_announcement_id_idx`(`announcement_id`),
+    INDEX `announcement_read_receipt_user_id_idx`(`user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `announcement_read_receipt` ADD CONSTRAINT `announcement_read_receipt_announcement_id_fkey` FOREIGN KEY (`announcement_id`) REFERENCES `announcement`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `announcement_read_receipt` ADD CONSTRAINT `announcement_read_receipt_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,7 @@ model user {
   pledge_callings  pledge_caller[] @relation("pledge_caller_user")
   pledges          pledger[]       @relation("pledger_user")
   announcements_created announcement[] @relation("announcement_creator")
+  announcement_read_receipts announcement_read_receipt[]
   sermon_series_created sermon_series[] @relation("sermon_series_creator")
   stock_notification_requests stock_notification_requests[]
 
@@ -308,6 +309,7 @@ model department_join_request {
 model position {
   id                   Int                    @id @default(autoincrement())
   name                 String
+  category             String?
   department_id        Int?
   description          String?
   branch_id            Int?
@@ -2459,15 +2461,31 @@ model announcement {
   created_at    DateTime              @default(now())
   updated_at    DateTime              @updatedAt
 
-  branch     branch?     @relation(fields: [branch_id], references: [id])
-  department department? @relation(fields: [department_id], references: [id])
-  position   position?   @relation(fields: [position_id], references: [id])
-  creator    user        @relation("announcement_creator", fields: [created_by], references: [id])
+  branch        branch?                     @relation(fields: [branch_id], references: [id])
+  department    department?                 @relation(fields: [department_id], references: [id])
+  position      position?                   @relation(fields: [position_id], references: [id])
+  creator       user                        @relation("announcement_creator", fields: [created_by], references: [id])
+  read_receipts announcement_read_receipt[]
 
   @@index([branch_id])
   @@index([department_id])
   @@index([position_id])
   @@index([created_by])
+}
+
+model announcement_read_receipt {
+  id              Int      @id @default(autoincrement())
+  announcement_id Int
+  user_id         Int
+  read_at         DateTime @default(now())
+  created_at      DateTime @default(now())
+
+  announcement announcement @relation(fields: [announcement_id], references: [id], onDelete: Cascade)
+  user         user         @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([announcement_id, user_id], map: "announcement_read_receipt_announcement_user_key")
+  @@index([announcement_id], map: "announcement_read_receipt_announcement_id_idx")
+  @@index([user_id], map: "announcement_read_receipt_user_id_idx")
 }
 
 enum sermon_status {

--- a/src/modules/announcements/announcementController.ts
+++ b/src/modules/announcements/announcementController.ts
@@ -223,4 +223,62 @@ export class announcementController {
       });
     }
   };
+
+  unreadCount = async (req: Request, res: Response) => {
+    try {
+      const actorUserId = getActorUserId(req);
+      if (!actorUserId) {
+        return res.status(401).json({
+          message: "A valid authenticated user is required",
+          data: null,
+        });
+      }
+
+      const unreadCount = await announcementService.getUnreadCountForUser(
+        actorUserId,
+      );
+
+      return res.status(200).json({
+        message: "Unread count retrieved successfully",
+        data: { unreadCount },
+      });
+    } catch (error) {
+      return res.status(500).json({
+        message: (error as Error).message || "Failed to get unread count",
+        data: null,
+      });
+    }
+  };
+
+  markAsRead = async (req: Request, res: Response) => {
+    try {
+      const actorUserId = getActorUserId(req);
+      if (!actorUserId) {
+        return res.status(401).json({
+          message: "A valid authenticated user is required",
+          data: null,
+        });
+      }
+
+      const id = toPositiveInt(req.params?.id);
+      if (!id) {
+        return res.status(400).json({ message: "Invalid id", data: null });
+      }
+
+      const receipt = await announcementService.markAnnouncementAsRead(
+        actorUserId,
+        id,
+      );
+
+      return res
+        .status(200)
+        .json({ message: "Announcement marked as read", data: receipt });
+    } catch (error) {
+      const statusCode = getStatusCode(error) ?? 500;
+      return res.status(statusCode).json({
+        message: (error as Error).message || "Failed to mark announcement as read",
+        data: null,
+      });
+    }
+  };
 }

--- a/src/modules/announcements/announcementRoute.ts
+++ b/src/modules/announcements/announcementRoute.ts
@@ -10,8 +10,10 @@ dotenv.config();
 
 const router = Router();
 
-// `/mine` must be registered before `/:id` so it is not captured as an id.
+// `/mine` and `/unread-count` must be registered before `/:id` so they are
+// not captured as an id.
 router.get("/mine", [protect], controller.mine);
+router.get("/unread-count", [protect], controller.unreadCount);
 
 router.get("/", [protect, permissions.can_view_announcements], controller.list);
 router.get(
@@ -35,6 +37,7 @@ router.post(
   [protect, permissions.can_manage_announcements],
   controller.publish,
 );
+router.patch("/:id/read", [protect], controller.markAsRead);
 
 router.delete(
   "/:id",

--- a/src/modules/announcements/announcementService.ts
+++ b/src/modules/announcements/announcementService.ts
@@ -301,14 +301,18 @@ const publishAnnouncement = async (id: number, actorUserId?: number) => {
   return { announcement: published, recipientCount: recipientIds.length };
 };
 
-const listForUser = async (userId: number, skip = 0, take = 20) => {
+// Shared by listForUser and getUnreadCountForUser so the audience-targeting
+// rules only live in one place. Returns null when the user doesn't exist.
+const buildVisibleAnnouncementsWhere = async (
+  userId: number,
+): Promise<Prisma.announcementWhereInput | null> => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { id: true, is_user: true, position_id: true, branch_id: true },
   });
 
   if (!user) {
-    return { data: [], total: 0 };
+    return null;
   }
 
   const [headedDepartments, positionRows, membershipRows] = await Promise.all([
@@ -358,14 +362,22 @@ const listForUser = async (userId: number, skip = 0, take = 20) => {
     OR: [{ branch_id: user.branch_id }, { branch_id: null }],
   };
 
-  const where: Prisma.announcementWhereInput = {
-    AND: [{ status: "PUBLISHED" }, { OR: or }, branchFilter],
-  };
+  return { AND: [{ status: "PUBLISHED" }, { OR: or }, branchFilter] };
+};
 
-  const [data, total] = await prisma.$transaction([
+const listForUser = async (userId: number, skip = 0, take = 20) => {
+  const where = await buildVisibleAnnouncementsWhere(userId);
+  if (!where) {
+    return { data: [], total: 0 };
+  }
+
+  const [rows, total] = await prisma.$transaction([
     prisma.announcement.findMany({
       where,
-      include: announcementInclude,
+      include: {
+        ...announcementInclude,
+        read_receipts: { where: { user_id: userId }, select: { id: true } },
+      },
       orderBy: { published_at: "desc" },
       skip,
       take,
@@ -373,7 +385,44 @@ const listForUser = async (userId: number, skip = 0, take = 20) => {
     prisma.announcement.count({ where }),
   ]);
 
+  const data = rows.map(({ read_receipts, ...announcement }) => ({
+    ...announcement,
+    isRead: read_receipts.length > 0,
+  }));
+
   return { data, total };
+};
+
+const getUnreadCountForUser = async (userId: number): Promise<number> => {
+  const where = await buildVisibleAnnouncementsWhere(userId);
+  if (!where) {
+    return 0;
+  }
+
+  return prisma.announcement.count({
+    where: { ...where, read_receipts: { none: { user_id: userId } } },
+  });
+};
+
+const markAnnouncementAsRead = async (userId: number, announcementId: number) => {
+  const existing = await prisma.announcement.findUnique({
+    where: { id: announcementId },
+    select: { id: true },
+  });
+  if (!existing) {
+    throw httpError("Announcement not found", 404);
+  }
+
+  return prisma.announcement_read_receipt.upsert({
+    where: {
+      announcement_id_user_id: {
+        announcement_id: announcementId,
+        user_id: userId,
+      },
+    },
+    update: { read_at: new Date() },
+    create: { announcement_id: announcementId, user_id: userId },
+  });
 };
 
 export const announcementService = {
@@ -385,4 +434,6 @@ export const announcementService = {
   publishAnnouncement,
   resolveRecipients,
   listForUser,
+  getUnreadCountForUser,
+  markAnnouncementAsRead,
 };

--- a/src/modules/appointment/appointment-controller.ts
+++ b/src/modules/appointment/appointment-controller.ts
@@ -122,16 +122,24 @@ export class AppointmentController {
   }
 
   /**
-   * @route   GET /appointment/availability/status
-   * @desc    Fetch availability in payload structure with slot/session status tags
+   * @route   GET /appointment/availability/status?date=YYYY-MM-DD&category=Something
+   * @desc    Fetch availability in payload structure with slot/session status tags.
+   *          ?date= pins every slot's status to that exact calendar date instead of
+   *          each slot's own next matching weekday; ?category= filters to staff whose
+   *          position category matches.
    */
   async getAvailabilityStatus(req: Request, res: Response) {
     try {
       const appointmentScope = (req as any).appointmentScope;
+      const date =
+        typeof req.query.date === "string" ? req.query.date : undefined;
+      const category =
+        typeof req.query.category === "string" ? req.query.category : undefined;
       const data =
         await AppointmentService.getAvailabilityWithSessionStatus(
           appointmentScope,
           req.query?.branch_id,
+          { date, category },
         );
 
       res.status(200).json({
@@ -139,7 +147,8 @@ export class AppointmentController {
         data,
       });
     } catch (error: any) {
-      res.status(500).json({
+      const statusCode = error?.message?.includes("date") ? 400 : 500;
+      res.status(statusCode).json({
         error: error.message || "Error fetching availability status",
       });
     }

--- a/src/modules/appointment/appointment-route.ts
+++ b/src/modules/appointment/appointment-route.ts
@@ -69,6 +69,7 @@ appointmentRouter.get(
 );
 
 // 9. Fetch users with daily sessions and booking status tags
+// (supports optional ?date=YYYY-MM-DD and ?category=)
 // URL: GET /appointment/availability/status
 appointmentRouter.get(
   "/availability/status",

--- a/src/modules/appointment/appointment-service.ts
+++ b/src/modules/appointment/appointment-service.ts
@@ -14,6 +14,7 @@ const availabilityInclude = {
       position: {
         select: {
           name: true,
+          category: true,
         },
       },
     },
@@ -816,8 +817,13 @@ export const AppointmentService = {
     return existing;
   },
 
-  // FETCH AVAILABILITY WITH SLOT/SESSION STATUS TAGS (ALL DAYS)
-  async getAvailabilityWithSessionStatus(scope?: AppointmentScope, branchId?: unknown) {
+  // FETCH AVAILABILITY WITH SLOT/SESSION STATUS TAGS (ALL DAYS, OR A SINGLE
+  // CALLER-SUPPLIED DATE WHEN filters.date IS GIVEN)
+  async getAvailabilityWithSessionStatus(
+    scope?: AppointmentScope,
+    branchId?: unknown,
+    filters?: { date?: string; category?: string },
+  ) {
     const excludedAttendeeIds =
       scope?.mode === "all" ? scope?.excludedAttendeeIds || [] : [];
     const availabilityWhere: any = {
@@ -827,6 +833,20 @@ export const AppointmentService = {
       availabilityWhere.userId = scope.userId;
     } else if (excludedAttendeeIds.length > 0) {
       availabilityWhere.userId = { notIn: excludedAttendeeIds };
+    }
+
+    const category = firstValidString(filters?.category);
+    if (category) {
+      availabilityWhere.user = { position: { category } };
+    }
+
+    // A caller-supplied date pins every slot's status to that exact day
+    // instead of each slot's own next matching weekday.
+    const requestedDateWindow = filters?.date
+      ? parseDateInput(filters.date)
+      : undefined;
+    if (requestedDateWindow) {
+      availabilityWhere.day = requestedDateWindow.dayName;
     }
 
     const allAvailabilities = await prisma.availability.findMany({
@@ -856,7 +876,7 @@ export const AppointmentService = {
     let rangeEnd: Date | undefined;
 
     for (const day of availabilityDays) {
-      const dayWindow = getNextDateWindowForDay(day);
+      const dayWindow = requestedDateWindow ?? getNextDateWindowForDay(day);
       dayWindows.set(day, dayWindow);
       if (!rangeStart || dayWindow.dayStart < rangeStart) {
         rangeStart = dayWindow.dayStart;
@@ -928,6 +948,8 @@ export const AppointmentService = {
       {
         userId: string;
         fullName: string | null;
+        position: string | null;
+        category: string | null;
         slotLimits: number[];
         bookedSessions: Array<{
           date: string;
@@ -959,6 +981,8 @@ export const AppointmentService = {
         grouped.set(availability.userId, {
           userId: String(availability.userId),
           fullName: availability.user?.name ?? null,
+          position: availability.user?.position?.name ?? null,
+          category: availability.user?.position?.category ?? null,
           slotLimits: [],
           bookedSessions: userBookedSessions,
           timeSlots: [],
@@ -1013,6 +1037,8 @@ export const AppointmentService = {
       return {
         userId: entry.userId,
         fullName: entry.fullName,
+        position: entry.position,
+        category: entry.category,
         maxBookingsPerSlot: resolvedMaxBookingsPerSlot,
         bookedSessions: entry.bookedSessions,
         timeSlots: entry.timeSlots.sort((a, b) => {

--- a/src/modules/programs/enrolmentService.ts
+++ b/src/modules/programs/enrolmentService.ts
@@ -21,6 +21,11 @@ type CompletedProgramContext = {
   completionDate: Date;
 };
 
+type NextProgramSuggestion = {
+  id: number;
+  title: string;
+};
+
 type ProgramCertificatePayload = {
   recipientFullName: string;
   programTitle: string;
@@ -29,6 +34,7 @@ type ProgramCertificatePayload = {
   certificateNumber: string;
   verificationUrl: string;
   qrCodeDataUrl: string;
+  nextPrograms: NextProgramSuggestion[];
 };
 
 const CERTIFICATE_NUMBER_PREFIX = "WWMHCSM";
@@ -576,6 +582,21 @@ export class EnrollmentService {
     throw new Error("Unable to generate a unique certificate number");
   }
 
+  private async resolveNextPrograms(
+    programId: number,
+  ): Promise<NextProgramSuggestion[]> {
+    const requiredForRows = await prisma.program_prerequisites.findMany({
+      where: { prerequisiteId: programId },
+      select: {
+        program: {
+          select: { id: true, title: true },
+        },
+      },
+    });
+
+    return requiredForRows.map((row) => row.program);
+  }
+
   private async buildCertificatePayload(
     context: CompletedProgramContext,
     certificate: {
@@ -586,7 +607,10 @@ export class EnrollmentService {
     const verificationUrl = this.buildCertificateVerificationUrl(
       certificate.certificateNumber,
     );
-    const qrCodeDataUrl = await generateQRDataUrl(verificationUrl);
+    const [qrCodeDataUrl, nextPrograms] = await Promise.all([
+      generateQRDataUrl(verificationUrl),
+      this.resolveNextPrograms(context.program.id),
+    ]);
 
     return {
       recipientFullName: context.user.name,
@@ -596,6 +620,7 @@ export class EnrollmentService {
       certificateNumber: certificate.certificateNumber,
       verificationUrl,
       qrCodeDataUrl,
+      nextPrograms,
     };
   }
 

--- a/src/modules/user/userController.ts
+++ b/src/modules/user/userController.ts
@@ -3066,6 +3066,57 @@ export const currentuser = async (req: Request, res: Response) => {
   }
 };
 
+const getWholeYearsSince = (date?: Date | null): number => {
+  if (!date) return 0;
+  const now = new Date();
+  let years = now.getFullYear() - date.getFullYear();
+  const hasHadAnniversaryThisYear =
+    now.getMonth() > date.getMonth() ||
+    (now.getMonth() === date.getMonth() && now.getDate() >= date.getDate());
+  if (!hasHadAnniversaryThisYear) years--;
+  return Math.max(0, years);
+};
+
+export const getMemberProfileStats = async (req: Request, res: Response) => {
+  try {
+    const authenticatedUserId = Number((req as any).user?.id);
+    if (!Number.isInteger(authenticatedUserId) || authenticatedUserId <= 0) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
+
+    const [userInfo, servicesAttended, soulsWon] = await Promise.all([
+      prisma.user_info.findUnique({
+        where: { user_id: authenticatedUserId },
+        select: { member_since: true },
+      }),
+      prisma.event_attendance.count({
+        where: {
+          user_id: authenticatedUserId,
+          event: { event_type: "SERVICE" },
+        },
+      }),
+      prisma.soul_won.count({
+        where: { wonById: authenticatedUserId },
+      }),
+    ]);
+
+    return res.status(200).json({
+      message: "Operation successful",
+      data: {
+        yearsServing: getWholeYearsSince(userInfo?.member_since),
+        servicesAttended,
+        soulsWon,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      message: "Something Went Wrong",
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+};
+
 export const updateUserPasswordToDefault = async (
   req: Request,
   res: Response,

--- a/src/modules/user/userRoutes.ts
+++ b/src/modules/user/userRoutes.ts
@@ -22,6 +22,7 @@ import {
   getUserFamily,
   linkChildren,
   currentuser,
+  getMemberProfileStats,
   ListUsersLight,
   activateAccount,
   updateUserPasswordToDefault,
@@ -132,6 +133,8 @@ userRouter.put(
 );
 
 userRouter.get("/current-user", [protect], currentuser);
+
+userRouter.get("/profile-stats", [protect], getMemberProfileStats);
 
 userRouter.get(
   "/set-default-passwords",


### PR DESCRIPTION
Introduce announcement read receipt tracking with unread count and mark-as-read endpoints. Add position category field to enable filtering staff by booking reason. Include member profile statistics endpoint showing years serving, services attended, and souls won. Enhance appointment availability filtering by date and category, and add suggested next programs to certificates.