### PR TITLE
Add booking-options endpoint for appointments

### DIFF
--- a/src/modules/appointment/appointment-controller.ts
+++ b/src/modules/appointment/appointment-controller.ts
@@ -155,6 +155,43 @@ export class AppointmentController {
   }
 
   /**
+   * @route   GET /appointment/availability/booking-options?date=YYYY-MM-DD&category=Something
+   * @desc    Same payload as `getAvailabilityStatus` (staff name/position/category,
+   *          their time slots, and per-slot AVAILABLE/BOOKED status — no requester
+   *          identity, no other members' appointment details), but unscoped: any
+   *          authenticated member needs the *full* staff list to pick who to book
+   *          with, not just their own ("own"-scoped) availability, which is what
+   *          `can_view_appointments_scoped` narrows non-privileged callers to.
+   *          Deliberately `protect`-only (no `can_view_appointments_scoped`) in the
+   *          route — safe because the returned fields carry nothing scoped access
+   *          was guarding in the first place.
+   */
+  async getBookingOptions(req: Request, res: Response) {
+    try {
+      const date =
+        typeof req.query.date === "string" ? req.query.date : undefined;
+      const category =
+        typeof req.query.category === "string" ? req.query.category : undefined;
+      const data =
+        await AppointmentService.getAvailabilityWithSessionStatus(
+          { mode: "all" },
+          req.query?.branch_id,
+          { date, category },
+        );
+
+      res.status(200).json({
+        message: "Booking options fetched successfully",
+        data,
+      });
+    } catch (error: any) {
+      const statusCode = error?.message?.includes("date") ? 400 : 500;
+      res.status(statusCode).json({
+        error: error.message || "Error fetching booking options",
+      });
+    }
+  }
+
+  /**
    * @route   POST /api/appointments/book
    * @desc    Member/Client books a specific time slot
    */

--- a/src/modules/appointment/appointment-route.ts
+++ b/src/modules/appointment/appointment-route.ts
@@ -77,6 +77,18 @@ appointmentRouter.get(
   appointmentController.getAvailabilityStatus,
 );
 
+// 9b. Fetch the full booking-options staff list (same payload as #9, but
+// `protect`-only — no `can_view_appointments_scoped` — so any authenticated
+// member sees every staff member's slots, not just their own "own"-scoped
+// availability, when picking who to book with). Payload carries no other
+// member's identity or appointment details, so opening it is safe.
+// URL: GET /appointment/availability/booking-options
+appointmentRouter.get(
+  "/availability/booking-options",
+  [protect],
+  appointmentController.getBookingOptions,
+);
+
 // 10. Update one availability slot by id
 // URL: PUT /appointment/availability/:id
 appointmentRouter.put(


### PR DESCRIPTION
Introduce a new unscoped booking options endpoint. Adds AppointmentController.getBookingOptions which calls AppointmentService.getAvailabilityWithSessionStatus({mode: 'all'}) and returns the full staff list/time-slot availability for a given date and optional category. Registers route GET /appointment/availability/booking-options protected by JWT only (no can_view_appointments_scoped) with rationale: the response contains no sensitive scoped data so all authenticated members can pick a staff. Includes basic date validation and maps date-related errors to 400, others to 500. Adds explanatory comment in routes.