### PR TITLE
Add Paystack checkout; accept product_id

### DIFF
--- a/src/libs/paystack/paystackTransaction.ts
+++ b/src/libs/paystack/paystackTransaction.ts
@@ -11,7 +11,8 @@ export type PaystackInitializeInput = {
   amount: number;
   currency: string;
   reference: string;
-  subaccount: string;
+  /** Omit for a plain charge to the main account (no split payment). */
+  subaccount?: string;
   /**
    * Flat amount, in minor units, routed to the main account rather than the
    * subaccount. Set to the fee, so the subaccount receives exactly the donation

--- a/src/modules/orders/orderController.ts
+++ b/src/modules/orders/orderController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { OrderService, InsufficientStockError } from "./orderService";
+import { isPaystackFailure } from "../../libs/paystack/paystackClient";
 
 const orderService = new OrderService();
 
@@ -13,7 +14,11 @@ export class OrderController {
         data: order,
       });
     } catch (error: any) {
-      const status = error instanceof InsufficientStockError ? 409 : 400;
+      const status = error instanceof InsufficientStockError
+        ? 409
+        : isPaystackFailure(error)
+        ? error.statusCode
+        : 400;
       return res.status(status).json({
         success: false,
         message: error.message || "Failed to create order",

--- a/src/modules/orders/orderService.ts
+++ b/src/modules/orders/orderService.ts
@@ -4,6 +4,10 @@ import crypto from "crypto";
 import { toSentenceCase } from "../../utils";
 import { notificationService } from "../notifications/notificationService";
 import { stockNotificationService } from "../products/stockNotificationService";
+import {
+  initializeTransaction,
+  verifyTransaction,
+} from "../../libs/paystack/paystackTransaction";
 
 export type StockShortage = {
   name: string;
@@ -79,7 +83,10 @@ export class OrderService {
     items: {
       market_id?: number | string;
       name: string;
-      id: string;
+      // Web checkout sends `product_id`; mobile sends `id` (falling back to
+      // `product_id`). Accept either — see resolveItemStock/buildItems.
+      id?: number | string;
+      product_id?: number | string;
       price_amount: number;
       price_currency: string;
       quantity: number;
@@ -183,13 +190,22 @@ export class OrderService {
     const orderNumber = this.generateOrderNumber(order.id);
 
     if (data.payment_type === "paystack") {
-      const response = await this.verifyPayment(clientReference);
-      const status =
-        response.status === 200 && response.data.data.status === "success"
-          ? "success"
-          : "failed";
+      const updated_order = await this.updateOrderPayment(
+        order.id,
+        "pending",
+        orderNumber,
+      );
+      const paystackResponse = await this.initializePaystackTransaction(
+        order,
+        data.return_url,
+      );
 
-      return this.updateOrderPayment(order.id, status, orderNumber);
+      return {
+        message: "Paystack payment initiated",
+        checkoutUrl: paystackResponse.authorization_url,
+        clientReference: paystackResponse.reference,
+        updated_order,
+      };
     } else {
       const updated_order = await this.updateOrderPayment(
         order.id,
@@ -402,18 +418,6 @@ export class OrderService {
     };
   }
 
-  private async verifyPayment(reference: string) {
-    return axios.get(
-      `https://api.paystack.co/transaction/verify/${reference}`,
-      {
-        headers: {
-          Authorization: `Bearer ${process.env.PAYSTACK_SECRET_KEY}`,
-          "Content-Type": "application/json",
-        },
-      },
-    );
-  }
-
   async verifyPaymentStatus(order_number: string) {
     const order = await prisma.orders.findFirst({
       where: { order_number },
@@ -426,9 +430,8 @@ export class OrderService {
     if (order.payment_status === "success")
       return { message: "Payment already verified", order: null };
 
-    const response = await this.verifyPayment(order.reference);
-    const status =
-      response.data.data.status === "success" ? "success" : "failed";
+    const transaction = await verifyTransaction(order.reference);
+    const status = transaction.status === "success" ? "success" : "failed";
 
     const updatedOrder = await this.updateOrderPayment(
       order.id,
@@ -611,6 +614,27 @@ export class OrderService {
     return response.data.data;
   }
 
+  /**
+   * Starts a Paystack transaction for an order and returns the checkout
+   * (authorization) URL to redirect the buyer to. Verification after the
+   * buyer returns is handled separately by verifyPaymentStatus.
+   */
+  async initializePaystackTransaction(order: any, return_url: string | null) {
+    return initializeTransaction({
+      email: order.billing_details.email,
+      // Paystack takes minor units (pesewas/cents); order.total_amount is
+      // stored in major units.
+      amount: Math.round(order.total_amount * 100),
+      currency: order.items[0]?.price_currency || "GHS",
+      reference: order.reference,
+      ...(return_url && { callback_url: return_url }),
+      metadata: {
+        order_id: order.id,
+        order_number: order.order_number,
+      },
+    });
+  }
+
   async checkHubtelTransactionStatus(clientReference: string) {
     try {
       const posId = process.env.HUBTEL_POS_ID;
@@ -706,14 +730,29 @@ export class OrderService {
   }
 
   private async resolveItemStock(
-    items: { id: string | number; name: string; color: string; size: string; quantity: number }[],
+    items: {
+      id?: string | number;
+      product_id?: string | number;
+      name: string;
+      color: string;
+      size: string;
+      quantity: number;
+    }[],
   ): Promise<ResolvedOrderItem[]> {
-    const invalidItem = items.find((item) => !Number.isInteger(Number(item.id)));
+    // Web checkout items carry `product_id`, not `id` — fall back so both
+    // client shapes resolve to the same product id.
+    const invalidItem = items.find(
+      (item) => !Number.isInteger(Number(item.id ?? item.product_id)),
+    );
     if (invalidItem) {
-      throw new Error(`Invalid product id "${invalidItem.id}" for item "${invalidItem.name}"`);
+      throw new Error(
+        `Invalid product id "${invalidItem.id ?? invalidItem.product_id}" for item "${invalidItem.name}"`,
+      );
     }
 
-    const productIds = [...new Set(items.map((item) => Number(item.id)))];
+    const productIds = [
+      ...new Set(items.map((item) => Number(item.id ?? item.product_id))),
+    ];
 
     const products = await prisma.products.findMany({
       where: { id: { in: productIds } },
@@ -747,7 +786,7 @@ export class OrderService {
     );
 
     return items.map((item) => {
-      const productId = Number(item.id);
+      const productId = Number(item.id ?? item.product_id);
       const product = productById.get(productId);
       const stockManaged = product?.stock_managed === "yes";
       const quantity = Number(item.quantity);
@@ -792,7 +831,7 @@ export class OrderService {
       const match = resolved[index];
       return {
         name: item.name,
-        product_id: Number(item.id),
+        product_id: Number(item.id ?? item.product_id),
         price_amount: item.price_amount,
         market_id: Number(item.market_id),
         price_currency: item.price_currency,


### PR DESCRIPTION
Merges main into production.

Includes:
- Paystack checkout: non-blocking subaccount, initializeTransaction/verifyTransaction wiring, initializePaystackTransaction returns checkout URL + reference, Paystack errors mapped to controller status codes.
- Order item parsing accepts `product_id` or `id` (validation, mapping, error messages) — fixes "provided product id \"undefined\"" error from web checkout (ICartItem never carried `id`, only `product_id`; mobile already sent `id` as a fallback).

Verified: `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)