### PR TITLE
fix: allow guest storefront access to products/markets/orders

### DIFF
--- a/src/middleWare/authorization.ts
+++ b/src/middleWare/authorization.ts
@@ -1431,6 +1431,20 @@ export class Permissions {
     next: NextFunction,
   ) => {
     const errorMessage = "Not authorized to create order for this user";
+
+    // Guest checkout: no token supplied at all — let the storefront visitor
+    // through with no user scoping. orderService already treats user_id as
+    // nullable for this case. A token that IS present but invalid/expired
+    // still falls through to getAccessContext below and gets rejected as usual.
+    if (!this.extractToken(req)) {
+      if (!(req as any).body || typeof (req as any).body !== "object") {
+        (req as any).body = {};
+      }
+      (req as any).body.user_id = null;
+      (req as any).orderScope = { mode: "guest", userId: null };
+      return next();
+    }
+
     const context = await this.getAccessContext(req, res, errorMessage);
     if (!context) return;
 

--- a/src/modules/marketplace/marketRouter.ts
+++ b/src/modules/marketplace/marketRouter.ts
@@ -32,7 +32,10 @@ marketRouter.put(
   [protect, permissions.can_manage_marketplace],
   marketController.restoreMarket,
 );
-marketRouter.get("/list-markets", [protect], marketController.listMarkets);
+// Public storefront read: guests browsing /out/products fetch markets for the
+// filter bar with no token. Scoping comes from an explicit branch_id query
+// param, not req.user — see marketService.getAllMarkets.
+marketRouter.get("/list-markets", marketController.listMarkets);
 marketRouter.get(
   "/list-markets-by-event",
   [protect],

--- a/src/modules/orders/orderRoutes.ts
+++ b/src/modules/orders/orderRoutes.ts
@@ -72,9 +72,11 @@ const protect = permissions.protect;
  *       400:
  *         description: Failed to create order
  */
+// No `protect` here: guest storefront checkout has no token. can_create_order_scoped
+// handles both the authenticated-member path and the anonymous-guest path itself.
 orderRouter.post(
   "/create-order",
-  [protect, permissions.can_create_order_scoped],
+  [permissions.can_create_order_scoped],
   orderController.create,
 );
 

--- a/src/modules/orders/orderService.ts
+++ b/src/modules/orders/orderService.ts
@@ -151,7 +151,10 @@ export class OrderService {
     const order = await prisma.$transaction(async (tx) => {
       const created = await tx.orders.create({
         data: {
-          user_id: Number(data.user_id) ?? null,
+          // `Number(data.user_id) ?? null` was wrong for guests: Number(undefined)
+          // is NaN, and NaN is not nullish, so `?? null` never caught it — Prisma
+          // would reject the NaN for this Int? column. Guard explicitly instead.
+          user_id: data.user_id != null ? Number(data.user_id) : null,
           total_amount: parseFloat(data.total_amount.toString()),
           reference: clientReference,
           items: { create: this.buildItems(data.items, resolvedItems) },

--- a/src/modules/products/productRouter.ts
+++ b/src/modules/products/productRouter.ts
@@ -1006,13 +1006,13 @@ productRouter.put(
   [protect, permissions.can_manage_marketplace],
   productController.restoreProduct,
 );
-productRouter.get("/list-products", [protect], productController.listProducts);
+// Public storefront reads: guests browsing /out/products must not be forced to sign in.
+productRouter.get("/list-products", productController.listProducts);
 productRouter.get(
   "/list-products-by-market",
-  [protect],
   productController.listProductsByMarketId,
 );
-productRouter.get("/get-product-by-id", [protect], productController.getProductById);
+productRouter.get("/get-product-by-id", productController.getProductById);
 //product type
 productRouter.post(
   "/create-product-type",
@@ -1058,7 +1058,6 @@ productRouter.put(
 );
 productRouter.get(
   "/list-product-category",
-  [protect],
   productController.listProductCategories,
 );
 


### PR DESCRIPTION
The /out/products storefront route is public, but every endpoint it calls required the `protect` auth middleware, so anonymous visitors got 401 "You are not signed in" on page load and would have hit the same wall placing an order.

- product/list-products, list-products-by-market, get-product-by-id, list-product-category: drop `protect`. Controllers/services never read req.user for these — pure catalog reads scoped by query params.
- market/list-markets: same — scoping comes from an explicit branch_id query param, not req.user.
- orders/create-order: drop `protect`; can_create_order_scoped now branches on whether a token is present. No token -> guest checkout, orderScope set to "guest", body.user_id left null. Token present -> existing member-scoping logic, unchanged (still rejects bad/expired tokens as before).
- orderService.create: fix `Number(data.user_id) ?? null`, which silently produced NaN for guests (Number(undefined) is NaN, and NaN isn't nullish so `??` never caught it) — would have thrown a Prisma error on this Int? column the moment guest checkout got unblocked.

DB schema (orders.user_id) and the frontend checkout flow already supported guest orders; only these auth gates were blocking it.